### PR TITLE
Handle SocketTimeoutException thrown when new connection to Aerospike is opened

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/core/DefaultAerospikeExceptionTranslator.java
+++ b/src/main/java/org/springframework/data/aerospike/core/DefaultAerospikeExceptionTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,17 @@ package org.springframework.data.aerospike.core;
 
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.ResultCode;
-import org.springframework.dao.*;
-import org.springframework.data.keyvalue.core.UncategorizedKeyValueException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataRetrievalFailureException;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.dao.TransientDataAccessResourceException;
 
 /**
  * @author Peter Milne
+ * @author Anastasiia Smirnova
  * This class translates the AerospikeException and result code
  * to a DataAccessException.
  */
@@ -37,6 +43,13 @@ public class DefaultAerospikeExceptionTranslator implements AerospikeExceptionTr
 		if (cause instanceof AerospikeException){
 			int resultCode = ((AerospikeException)cause).getResultCode();
 			String msg = cause.getMessage();
+			if (cause instanceof AerospikeException.Connection) {
+				if (resultCode == ResultCode.SERVER_NOT_AVAILABLE) {
+					// we should throw query timeout exception only when opening new connection fails with SocketTimeoutException.
+					// see com.aerospike.client.cluster.Connection for more details
+					return new QueryTimeoutException(msg, cause);
+				}
+			}
 			switch (resultCode) {
 			/*
 			 * Future enhancements will be more elaborate 

--- a/src/test/java/org/springframework/data/aerospike/core/DefaultAerospikeExceptionTranslatorTest.java
+++ b/src/test/java/org/springframework/data/aerospike/core/DefaultAerospikeExceptionTranslatorTest.java
@@ -70,10 +70,24 @@ public class DefaultAerospikeExceptionTranslatorTest {
     }
 
     @Test
+    public void shouldTranslateConnectErrorWithNoMoreConnections() {
+        AerospikeException.Connection cause = new AerospikeException.Connection(ResultCode.NO_MORE_CONNECTIONS, "msg");
+        DataAccessException actual = translator.translateExceptionIfPossible(cause);
+        assertThat(actual).isExactlyInstanceOf(TransientDataAccessResourceException.class);
+    }
+
+    @Test
     public void shouldTranslateQueryKeyBusyError() {
         AerospikeException cause = new AerospikeException(ResultCode.KEY_BUSY);
         DataAccessException actual = translator.translateExceptionIfPossible(cause);
         assertThat(actual).isExactlyInstanceOf(TransientDataAccessResourceException.class);
+    }
+
+    @Test
+    public void shouldTranslateConnectErrorToAerospike() {
+        AerospikeException.Connection cause = new AerospikeException.Connection("msg");
+        DataAccessException actual = translator.translateExceptionIfPossible(cause);
+        assertThat(actual).isExactlyInstanceOf(QueryTimeoutException.class);
     }
 
     @Test


### PR DESCRIPTION
```
org.springframework.dao.RecoverableDataAccessException: Error -8,1,50,50,0, 3000: 
java.net.SocketTimeoutException; nested exception is 
com.aerospike.client.AerospikeException$Connection: Error -8,1,50,50,0, 3000: 
java.net.SocketTimeoutException at 
org.springframework.data.aerospike.core.DefaultAerospikeExceptionTranslator.translateExceptionIfPossible(DefaultAerospikeExceptionTranslator.java:60) at 
org.springframework.data.aerospike.core.AerospikeTemplate.findById(AerospikeTemplate.java:276)
```