### PR TITLE
Cleanup AerospikeTemplate.save method

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/convert/AerospikeWriteData.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/AerospikeWriteData.java
@@ -80,6 +80,10 @@ public class AerospikeWriteData {
 		return Optional.ofNullable(version);
 	}
 
+	public boolean hasVersion() {
+		return version != null;
+	}
+
 	public void setVersion(Integer version) {
 		this.version = version;
 	}


### PR DESCRIPTION
As preparation for `AerospikeTemplate.update` method fix.

Made minimal changes to extract methods that will be used in fix for `AerospikeTemplate.update` method.