### PR TITLE
Fixes AerospikeTemplate insert and update methods to respect version property

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeOperations.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeOperations.java
@@ -49,7 +49,9 @@ public interface AerospikeOperations {
 	<T> String getSetName(Class<T> entityClass);
 	
 	/**
-	 * Insert operation using the WritePolicy.recordExisits policy of CREATE_ONLY 
+	 * Insert operation using {@link com.aerospike.client.policy.RecordExistsAction#CREATE_ONLY} policy.
+	 *
+	 * If document has version property it will be updated with the server's version after successful operation.
 	 * @param document
 	 */
 	<T> void insert(T document);
@@ -65,10 +67,11 @@ public interface AerospikeOperations {
 	 * If document has version property - CAS algorithm is used for updating record.
 	 * Version property is used for deciding whether to create new record or update existing.
 	 * If version is set to zero - new record will be created, creation will fail is such record already exists.
-	 * If version is greater than zero - existing record will be updated with RecordExistsAction.REPLACE_ONLY policy
+	 * If version is greater than zero - existing record will be updated with {@link com.aerospike.client.policy.RecordExistsAction#REPLACE_ONLY} policy
 	 * taking into consideration the version property of the document.
+	 * Version property will be updated with the server's version after successful operation.
 	 *
-	 * If document does not have version property - record is updated with RecordExistsAction.REPLACE policy.
+	 * If document does not have version property - record is updated with {@link com.aerospike.client.policy.RecordExistsAction#REPLACE} policy.
 	 * This means that when such record does not exist it will be created, otherwise updated.
 	 * @param document
 	 */
@@ -82,7 +85,10 @@ public interface AerospikeOperations {
 	<T> void persist(T document, WritePolicy writePolicy);
 
 	/**
-	 * Update operation using the WritePolicy.recordExisits policy of UPDATE_ONLY
+	 * Update operation using {@link com.aerospike.client.policy.RecordExistsAction#REPLACE_ONLY} policy
+	 * taking into consideration the version property of the document if it is present.
+	 *
+	 * If document has version property it will be updated with the server's version after successful operation.
 	 * @param objectToUpdate
 	 */
 	<T> void update(T objectToUpdate);

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -273,7 +273,7 @@ abstract class BaseAerospikeTemplate {
         return expectGeneration(data, recordExistsAction);
     }
 
-    WritePolicy ignoreGeneration() {
+    WritePolicy ignoreGenerationDeletePolicy() {
         return WritePolicyBuilder.builder(this.client.writePolicyDefault)
                 .generationPolicy(GenerationPolicy.NONE)
                 .build();

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
@@ -270,7 +270,7 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
         AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(entityClass);
 
         return reactorClient
-                .delete(ignoreGeneration(), getKey(id, entity))
+                .delete(ignoreGenerationDeletePolicy(), getKey(id, entity))
                 .map(k -> true)
                 .onErrorMap(this::translateError);
     }
@@ -282,7 +282,7 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
         AerospikeWriteData data = writeData(objectToDelete);
 
         return this.reactorClient
-                .delete(ignoreGeneration(), data.getKey())
+                .delete(ignoreGenerationDeletePolicy(), data.getKey())
                 .map(key -> true)
                 .onErrorMap(this::translateError);
     }

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateDeleteTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateDeleteTests.java
@@ -1,0 +1,86 @@
+package org.springframework.data.aerospike.core;
+
+import com.aerospike.client.policy.GenerationPolicy;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.aerospike.BaseIntegrationTests;
+import org.springframework.data.aerospike.SampleClasses.VersionedClass;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AerospikeTemplateDeleteTests extends BaseIntegrationTests {
+
+	private String id;
+
+	@Before
+	public void setUp() {
+		this.id = nextId();
+	}
+
+	@Test
+	public void deleteByObject_ignoresDocumentVersionEvenIfDefaultGenerationPolicyIsSet() {
+		GenerationPolicy initialGenerationPolicy = client.writePolicyDefault.generationPolicy;
+		client.writePolicyDefault.generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL;
+		try {
+			VersionedClass initialDocument = new VersionedClass(id, "a");
+			template.insert(initialDocument);
+			template.update(new VersionedClass(id, "b", initialDocument.version));
+
+			boolean deleted = template.delete(initialDocument);
+			assertThat(deleted).isTrue();
+		} finally {
+			client.writePolicyDefault.generationPolicy = initialGenerationPolicy;
+		}
+	}
+
+	@Test
+	public void deleteByObject_ignoresVersionEvenIfDefaultGenerationPolicyIsSet() {
+		GenerationPolicy initialGenerationPolicy = client.writePolicyDefault.generationPolicy;
+		client.writePolicyDefault.generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL;
+		try {
+			Person initialDocument = new Person(id, "a");
+			template.insert(initialDocument);
+			template.update(new Person(id, "b"));
+
+			boolean deleted = template.delete(initialDocument);
+			assertThat(deleted).isTrue();
+		} finally {
+			client.writePolicyDefault.generationPolicy = initialGenerationPolicy;
+		}
+	}
+
+	@Test
+	public void deleteByObject_deletesDocument() {
+		Person document = new Person(id, "QLastName", 21);
+		template.insert(document);
+
+		boolean deleted = template.delete(document);
+		assertThat(deleted).isTrue();
+
+		Person result = template.findById(id, Person.class);
+		assertThat(result).isNull();
+	}
+
+	@Test
+	public void deleteById_deletesDocument() {
+		Person document = new Person(id, "QLastName", 21);
+		template.insert(document);
+
+		boolean deleted = template.delete(id, Person.class);
+		assertThat(deleted).isTrue();
+
+		Person result = template.findById(id, Person.class);
+		assertThat(result).isNull();
+	}
+
+	@Test
+	public void deleteById_returnsFalseIfValueIsAbsent() {
+		assertThat(template.delete(id, Person.class)).isFalse();
+	}
+
+	@Test
+	public void deleteByObject_returnsFalseIfValueIsAbsent() {
+		Person one = Person.builder().id(id).firstName("tya").emailAddress("gmail.com").build();
+		assertThat(template.delete(one)).isFalse();
+	}
+}

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateInsertTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateInsertTests.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.aerospike.core;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.policy.Policy;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.aerospike.AsyncUtils;
+import org.springframework.data.aerospike.BaseIntegrationTests;
+import org.springframework.data.aerospike.SampleClasses;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AerospikeTemplateInsertTests extends BaseIntegrationTests {
+
+	private String id;
+
+	@Before
+	public void setUp() {
+		this.id = nextId();
+	}
+
+	@Test
+	public void insertsAndFindsWithCustomCollectionSet() {
+		SampleClasses.CustomCollectionClass initial = new SampleClasses.CustomCollectionClass(id, "data0");
+		template.insert(initial);
+
+		Record record = client.get(new Policy(), new Key(getNameSpace(), "custom-set", id));
+
+		assertThat(record.getString("data")).isEqualTo("data0");
+		assertThat(template.findById(id, SampleClasses.CustomCollectionClass.class)).isEqualTo(initial);
+	}
+
+	@Test
+	public void insertsDocumentWithListMapDateStringLongValues() {
+		Map<String, String> map = Collections.singletonMap("k", "v");
+		Person friend = new Person(nextId(), "Anna", 43);
+		List<String> list = Arrays.asList("a", "b", "c");
+		String email = "dave@gmail.com";
+		Date dateOfBirth = new Date();
+		Person customer = new Person(id, "Dave", 45, map, friend, true, dateOfBirth, list, email);
+
+		template.insert(customer);
+
+		Person actual = template.findById(id, Person.class);
+		assertThat(actual.getId()).isEqualTo(id);
+		assertThat(actual.getAge()).isEqualTo(45);
+		assertThat(actual.getFirstName()).isEqualTo("Dave");
+		assertThat(actual.getMap()).isEqualTo(map);
+		assertThat(actual.getFriend()).isEqualToIgnoringGivenFields(friend, "id");//metadata fields are not saved for internal structures
+		assertThat(actual.isActive()).isTrue();
+		assertThat(actual.getDateOfBirth()).isEqualTo(dateOfBirth);
+		assertThat(actual.getList()).isEqualTo(list);
+		assertThat(actual.getEmailAddress()).isEqualTo(email);
+	}
+
+	@Test
+	public void insertsAndFindsDocumentWithByteArrayField() {
+		SampleClasses.DocumentWithByteArray document = new SampleClasses.DocumentWithByteArray(id, new byte[]{1, 0, 0, 1, 1, 1, 0, 0});
+
+		template.insert(document);
+
+		SampleClasses.DocumentWithByteArray result = template.findById(id, SampleClasses.DocumentWithByteArray.class);
+		assertThat(result).isEqualTo(document);
+	}
+
+	@Test
+	public void insertsDocumentWithNullFields() {
+		SampleClasses.VersionedClass document = new SampleClasses.VersionedClass(id, null);
+
+		template.insert(document);
+
+		assertThat(document.getField()).isNull();
+	}
+
+	@Test
+	public void insertsDocumentWithZeroVersionIfThereIsNoDocumentWithSameKey() {
+		SampleClasses.VersionedClass document = new SampleClasses.VersionedClass(id, "any", 0);
+
+		template.insert(document);
+
+		assertThat(document.getVersion()).isEqualTo(1);
+	}
+
+	@Test
+	public void insertsDocumentWithVersionGreaterThanZeroIfThereIsNoDocumentWithSameKey() {
+		SampleClasses.VersionedClass document = new SampleClasses.VersionedClass(id, "any", 5);
+
+		template.insert(document);
+
+		assertThat(document.getVersion()).isEqualTo(1);
+	}
+
+	@Test
+	public void throwsExceptionForDuplicateId() {
+		Person person = new Person(id, "Amol", 28);
+
+		template.insert(person);
+		assertThatThrownBy(() -> template.insert(person))
+				.isInstanceOf(DuplicateKeyException.class);
+	}
+
+	@Test
+	public void throwsExceptionForDuplicateIdForVersionedDocument() {
+		SampleClasses.VersionedClass document = new SampleClasses.VersionedClass(id, "any", 5);
+
+		template.insert(document);
+		assertThatThrownBy(() -> template.insert(document))
+				.isInstanceOf(DuplicateKeyException.class);
+	}
+
+	@Test
+	public void insertsOnlyFirstDocumentAndNextAttemptsShouldFailWithDuplicateKeyExceptionForVersionedDocument() throws Exception {
+		AtomicLong counter = new AtomicLong();
+		AtomicLong duplicateKeyCounter = new AtomicLong();
+		int numberOfConcurrentSaves = 5;
+
+		AsyncUtils.executeConcurrently(numberOfConcurrentSaves, () -> {
+			long counterValue = counter.incrementAndGet();
+			String data = "value-" + counterValue;
+			try {
+				template.insert(new SampleClasses.VersionedClass(id, data));
+			} catch (DuplicateKeyException e) {
+				duplicateKeyCounter.incrementAndGet();
+			}
+		});
+
+		assertThat(duplicateKeyCounter.intValue()).isEqualTo(numberOfConcurrentSaves - 1);
+	}
+
+	@Test
+	public void insertsOnlyFirstDocumentAndNextAttemptsShouldFailWithDuplicateKeyExceptionForNonVersionedDocument() throws Exception {
+		AtomicLong counter = new AtomicLong();
+		AtomicLong duplicateKeyCounter = new AtomicLong();
+		int numberOfConcurrentSaves = 5;
+
+		AsyncUtils.executeConcurrently(numberOfConcurrentSaves, () -> {
+			long counterValue = counter.incrementAndGet();
+			String data = "value-" + counterValue;
+			try {
+				template.insert(new Person(id, data, 28));
+			} catch (DuplicateKeyException e) {
+				duplicateKeyCounter.incrementAndGet();
+			}
+		});
+
+		assertThat(duplicateKeyCounter.intValue()).isEqualTo(numberOfConcurrentSaves - 1);
+
+	}
+}

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Please do not add tests here. Instead add tests to AerospikeTemplateTests.
+ * Please do not add tests here. Instead add tests to AerospikeTemplate{NameOfTheMethod}Tests.
  * @author Oliver Gierke
  *
  */
@@ -61,26 +61,6 @@ public class AerospikeTemplateIntegrationTests extends BaseIntegrationTests {
 		scanPolicy.includeBinData = false;
 		client.scanAll(	scanPolicy, getNameSpace(), AerospikeTemplateIntegrationTests.SET_NAME_PERSON,
 				(key, record) -> client.delete(null, key), new String[] {});
-	}
-
-	@Test
-	public void testUpdate(){
-		Person customer = new Person("dave-001", "Dave", "Matthews");
-		template.insert(customer);
-		String newLastName = customer.getLastname() + "xx";
-		customer.setLastname(newLastName);
-		template.update(customer);
-		customer = template.findById("dave-001", Person.class);
-		Assert.assertEquals("Matthewsxx", customer.getLastname());
-	}
-
-	@Test
-	public void testInsert(){
-		Person customer = new Person("dave-002", "Dave", "Matthews");
-		template.insert(customer);
-		Record result = client.get(null, new Key(getNameSpace(), AerospikeTemplateIntegrationTests.SET_NAME_PERSON, "dave-002"));
-		Assert.assertEquals("Dave", result.getString("firstname"));
-		Assert.assertEquals("Matthews", result.getString("lastname"));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
@@ -1,0 +1,250 @@
+package org.springframework.data.aerospike.core;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.policy.Policy;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.dao.DataRetrievalFailureException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.aerospike.AsyncUtils;
+import org.springframework.data.aerospike.BaseIntegrationTests;
+import org.springframework.data.aerospike.SampleClasses;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AerospikeTemplateSaveTests extends BaseIntegrationTests {
+
+	private String id;
+
+	@Before
+	public void setUp() {
+		this.id = nextId();
+	}
+
+	//test for RecordExistsAction.REPLACE_ONLY policy
+	@Test
+	public void shouldReplaceAllBinsPresentInAerospikeWhenSavingDocument() {
+		Key key = new Key(getNameSpace(), "versioned-set", id);
+		SampleClasses.VersionedClass first = new SampleClasses.VersionedClass(id, "foo");
+		template.save(first);
+		addNewFieldToSavedDataInAerospike(key);
+
+		template.save(new SampleClasses.VersionedClass(id, "foo2", 2));
+
+		Record record2 = client.get(new Policy(), key);
+		assertThat(record2.bins.get("notPresent")).isNull();
+		assertThat(record2.bins.get("field")).isEqualTo("foo2");
+	}
+
+	@Test
+	public void shouldSaveAndSetVersion() {
+		SampleClasses.VersionedClass first = new SampleClasses.VersionedClass(id, "foo");
+		template.save(first);
+
+		assertThat(first.version).isEqualTo(1);
+		assertThat(template.findById(id, SampleClasses.VersionedClass.class).version).isEqualTo(1);
+	}
+
+	@Test
+	public void shouldNotSaveDocumentIfItAlreadyExistsWithZeroVersion() {
+		template.save(new SampleClasses.VersionedClass(id, "foo", 0));
+
+		assertThatThrownBy(() -> template.save(new SampleClasses.VersionedClass(id, "foo", 0)))
+				.isInstanceOf(OptimisticLockingFailureException.class);
+	}
+
+	@Test
+	public void shouldSaveDocumentWithEqualVersion() {
+		template.save(new SampleClasses.VersionedClass(id, "foo", 0));
+
+		template.save(new SampleClasses.VersionedClass(id, "foo", 1));
+		template.save(new SampleClasses.VersionedClass(id, "foo", 2));
+	}
+
+	@Test
+	public void shouldFailSaveNewDocumentWithVersionGreaterThanZero() {
+		assertThatThrownBy(() -> template.save(new SampleClasses.VersionedClass(id, "foo", 5)))
+				.isInstanceOf(DataRetrievalFailureException.class);
+	}
+
+	@Test
+	public void shouldUpdateNullField() {
+		SampleClasses.VersionedClass versionedClass = new SampleClasses.VersionedClass(id, null, 0);
+		template.save(versionedClass);
+
+		SampleClasses.VersionedClass saved = template.findById(id, SampleClasses.VersionedClass.class);
+		template.save(saved);
+	}
+
+	@Test
+	public void shouldUpdateNullFieldForClassWithVersionField() {
+		SampleClasses.VersionedClass versionedClass = new SampleClasses.VersionedClass(id, "field", 0);
+		template.save(versionedClass);
+
+		SampleClasses.VersionedClass byId = template.findById(id, SampleClasses.VersionedClass.class);
+		assertThat(byId.getField())
+				.isEqualTo("field");
+
+		template.save(new SampleClasses.VersionedClass(id, null, byId.version));
+
+		assertThat(template.findById(id, SampleClasses.VersionedClass.class).getField())
+				.isNull();
+	}
+
+	@Test
+	public void shouldUpdateNullFieldForClassWithoutVersionField() {
+		Person person = new Person(id,"Oliver");
+		person.setFirstName("First name");
+		template.insert(person);
+
+		assertThat(template.findById(id, Person.class)).isEqualTo(person);
+
+		person.setFirstName(null);
+		template.save(person);
+
+		assertThat(template.findById(id, Person.class).getFirstName()).isNull();
+	}
+
+	@Test
+	public void shouldUpdateExistingDocument() {
+		SampleClasses.VersionedClass one = new SampleClasses.VersionedClass(id, "foo", 0);
+		template.save(one);
+
+		template.save(new SampleClasses.VersionedClass(id, "foo1", one.version));
+
+		SampleClasses.VersionedClass value = template.findById(id, SampleClasses.VersionedClass.class);
+		assertThat(value.version).isEqualTo(2);
+		assertThat(value.field).isEqualTo("foo1");
+	}
+
+	@Test
+	public void shouldSetVersionWhenSavingTheSameDocument() {
+		SampleClasses.VersionedClass one = new SampleClasses.VersionedClass(id, "foo");
+		template.save(one);
+		template.save(one);
+		template.save(one);
+
+		assertThat(one.version).isEqualTo(3);
+	}
+
+	@Test
+	public void shouldUpdateAlreadyExistingDocument() throws Exception {
+		AtomicLong counter = new AtomicLong();
+		int numberOfConcurrentSaves = 5;
+
+		SampleClasses.VersionedClass initial = new SampleClasses.VersionedClass(id, "value-0");
+		template.save(initial);
+		assertThat(initial.version).isEqualTo(1);
+
+		AsyncUtils.executeConcurrently(numberOfConcurrentSaves, () -> {
+			boolean saved = false;
+			while(!saved) {
+				long counterValue = counter.incrementAndGet();
+				SampleClasses.VersionedClass messageData = template.findById(id, SampleClasses.VersionedClass.class);
+				messageData.field = "value-" + counterValue;
+				try {
+					template.save(messageData);
+					saved = true;
+				} catch (OptimisticLockingFailureException e) {
+				}
+			}
+		});
+
+		SampleClasses.VersionedClass actual = template.findById(id, SampleClasses.VersionedClass.class);
+
+		assertThat(actual.field).isNotEqualTo(initial.field);
+		assertThat(actual.version).isNotEqualTo(initial.version);
+		assertThat(actual.version).isEqualTo(initial.version + numberOfConcurrentSaves);
+	}
+
+	@Test
+	public void shouldSaveOnlyFirstDocumentAndNextAttemptsShouldFailWithOptimisticLockingException() throws Exception {
+		AtomicLong counter = new AtomicLong();
+		AtomicLong optimisticLockCounter = new AtomicLong();
+		int numberOfConcurrentSaves = 5;
+
+		AsyncUtils.executeConcurrently(numberOfConcurrentSaves, () -> {
+			long counterValue = counter.incrementAndGet();
+			String data = "value-" + counterValue;
+			SampleClasses.VersionedClass messageData = new SampleClasses.VersionedClass(id, data);
+			try {
+				template.save(messageData);
+			} catch (OptimisticLockingFailureException e) {
+				optimisticLockCounter.incrementAndGet();
+			}
+		});
+
+		assertThat(optimisticLockCounter.intValue()).isEqualTo(numberOfConcurrentSaves - 1);
+	}
+
+	@Test
+	public void shouldSaveMultipleTimeDocumentWithoutVersion() {
+		SampleClasses.CustomCollectionClass one = new SampleClasses.CustomCollectionClass(id, "numbers");
+
+		template.save(one);
+		template.save(one);
+
+		assertThat(template.findById(id, SampleClasses.CustomCollectionClass.class)).isEqualTo(one);
+	}
+
+	@Test
+	public void shouldUpdateDocumentDataWithoutVersion() {
+		SampleClasses.CustomCollectionClass first = new SampleClasses.CustomCollectionClass(id, "numbers");
+		SampleClasses.CustomCollectionClass second = new SampleClasses.CustomCollectionClass(id, "hot dog");
+
+		template.save(first);
+		template.save(second);
+
+		assertThat(template.findById(id, SampleClasses.CustomCollectionClass.class)).isEqualTo(second);
+	}
+
+	@Test
+	public void rejectsNullObjectToBeSaved() {
+		assertThatThrownBy(() -> template.save(null))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void shouldConcurrentlyUpdateDocumentIfTouchOnReadIsTrue() throws Exception {
+		int numberOfConcurrentUpdate = 10;
+		AsyncUtils.executeConcurrently(numberOfConcurrentUpdate, new Runnable() {
+			@Override
+			public void run() {
+				try {
+					SampleClasses.DocumentWithTouchOnRead existing = template.findById(id, SampleClasses.DocumentWithTouchOnRead.class) ;
+					SampleClasses.DocumentWithTouchOnRead toUpdate;
+					if (existing != null) {
+						toUpdate = new SampleClasses.DocumentWithTouchOnRead(id, existing.getField() + 1, existing.getVersion());
+					} else {
+						toUpdate = new SampleClasses.DocumentWithTouchOnRead(id, 1);
+					}
+
+					template.save(toUpdate);
+				} catch (ConcurrencyFailureException e) {
+					//try again
+					run();
+				}
+			}
+		});
+
+		SampleClasses.DocumentWithTouchOnRead actual = template.findById(id, SampleClasses.DocumentWithTouchOnRead.class);
+		assertThat(actual.getField()).isEqualTo(numberOfConcurrentUpdate);
+	}
+
+	@Test
+	public void shouldSaveAndFindDocumentWithByteArrayField() {
+		SampleClasses.DocumentWithByteArray document = new SampleClasses.DocumentWithByteArray(id, new byte[]{1, 0, 0, 1, 1, 1, 0, 0});
+
+		template.save(document);
+
+		SampleClasses.DocumentWithByteArray result = template.findById(id, SampleClasses.DocumentWithByteArray.class);
+
+		assertThat(result).isEqualTo(document);
+	}
+
+}

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateUpdateTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateUpdateTests.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.aerospike.core;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.policy.Policy;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.dao.DataRetrievalFailureException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.aerospike.AsyncUtils;
+import org.springframework.data.aerospike.BaseIntegrationTests;
+import org.springframework.data.aerospike.SampleClasses;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AerospikeTemplateUpdateTests extends BaseIntegrationTests {
+
+	private String id;
+
+	@Before
+	public void setUp() {
+		this.id = nextId();
+	}
+
+	@Test
+	public void shouldThrowExceptionOnUpdateForNonexistingKey() {
+		assertThatThrownBy(() -> template.update(new Person(id, "svenfirstName", 11)))
+				.isInstanceOf(DataRetrievalFailureException.class);
+	}
+
+	@Test
+	public void updatesEvenIfDocumentNotChanged() {
+		Person person = new Person(id, "Wolfgan", 11);
+		template.insert(person);
+
+		template.update(person);
+
+		Person result = template.findById(id, Person.class);
+
+		assertThat(result.getAge()).isEqualTo(11);
+	}
+
+	@Test
+	public void updatesMultipleFields() {
+		Person person = new Person(id, null, 0);
+		template.insert(person);
+
+		template.update(new Person(id, "Andrew", 32));
+
+		assertThat(template.findById(id, Person.class)).satisfies(doc-> {
+			assertThat(doc.getFirstName()).isEqualTo("Andrew");
+			assertThat(doc.getAge()).isEqualTo(32);
+		});
+	}
+
+	@Test
+	public void updatesFieldValueAndDocumentVersion() {
+		SampleClasses.VersionedClass document = new SampleClasses.VersionedClass(id, "foobar");
+		template.insert(document);
+		assertThat(template.findById(id, SampleClasses.VersionedClass.class).version).isEqualTo(1);
+
+		document = new SampleClasses.VersionedClass(id, "foobar1", document.version);
+		template.update(document);
+		assertThat(template.findById(id, SampleClasses.VersionedClass.class)).satisfies(doc -> {
+			assertThat(doc.field).isEqualTo("foobar1");
+			assertThat(doc.version).isEqualTo(2);
+		});
+
+		document = new SampleClasses.VersionedClass(id, "foobar2", document.version);
+		template.update(document);
+		assertThat(template.findById(id, SampleClasses.VersionedClass.class)).satisfies(doc -> {
+			assertThat(doc.field).isEqualTo("foobar2");
+			assertThat(doc.version).isEqualTo(3);
+		});
+	}
+
+	@Test
+	public void updatesFieldToNull() {
+		SampleClasses.VersionedClass document = new SampleClasses.VersionedClass(id, "foobar");
+		template.insert(document);
+
+		document = new SampleClasses.VersionedClass(id, null, document.version);
+		template.update(document);
+		assertThat(template.findById(id, SampleClasses.VersionedClass.class)).satisfies(doc -> {
+			assertThat(doc.field).isNull();
+			assertThat(doc.version).isEqualTo(2);
+		});
+	}
+
+	@Test
+	public void setsVersionEqualToNumberOfModifications() {
+		SampleClasses.VersionedClass document = new SampleClasses.VersionedClass(id, "foobar");
+		template.insert(document);
+		template.update(document);
+		template.update(document);
+
+		Record raw = client.get(new Policy(), new Key(getNameSpace(), "versioned-set", id));
+		assertThat(raw.generation).isEqualTo(3);
+		SampleClasses.VersionedClass actual = template.findById(id, SampleClasses.VersionedClass.class);
+		assertThat(actual.version).isEqualTo(3);
+	}
+
+	@Test
+	public void onlyFirstUpdateSucceedsAndNextAttemptsShouldFailWithOptimisticLockingFailureExceptionForVersionedDocument() throws Exception {
+		SampleClasses.VersionedClass document = new SampleClasses.VersionedClass(id, "foobar");
+		template.insert(document);
+
+		AtomicLong counter = new AtomicLong();
+		AtomicLong optimisticLock = new AtomicLong();
+		int numberOfConcurrentSaves = 5;
+
+		AsyncUtils.executeConcurrently(numberOfConcurrentSaves, () -> {
+			long counterValue = counter.incrementAndGet();
+			String data = "value-" + counterValue;
+			try {
+				template.update(new SampleClasses.VersionedClass(id, data, document.version));
+			} catch (OptimisticLockingFailureException e) {
+				optimisticLock.incrementAndGet();
+			}
+		});
+
+		assertThat(optimisticLock.intValue()).isEqualTo(numberOfConcurrentSaves - 1);
+	}
+
+	@Test
+	public void allConcurrentUpdatesSucceedForNonVersionedDocument() throws Exception {
+		Person document = new Person(id, "foobar");
+		template.insert(document);
+
+		AtomicLong counter = new AtomicLong();
+		int numberOfConcurrentSaves = 5;
+
+		AsyncUtils.executeConcurrently(numberOfConcurrentSaves, () -> {
+			long counterValue = counter.incrementAndGet();
+			String firstName = "value-" + counterValue;
+			template.update(new Person(id, firstName));
+		});
+
+		Person actual = template.findById(id, Person.class);
+		assertThat(actual.getFirstName()).startsWith("value-");
+	}
+}


### PR DESCRIPTION
Non backward compatible fixes:
- `AerospikeTemplate.insert` and `AerospikeTemplate.update` now considers version property of the document, handles error respectively and updates document's version property after operation is complete
- `AerospikeTemplate.update` policy was changed from `UPDATE_ONLY` to `REPLACE_ONLY`. (It was not possible to set any document's property to null value via `update` method)
- Update javadoc documentation for `AerospikeTemplate.insert`, `AerospikeTemplate.update` and `AerospikeTemplate.save` methods