### PR TITLE
save, insert, update documents with version field works incorrectly if version field is of object type (Long)

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/convert/AerospikeWriteData.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/AerospikeWriteData.java
@@ -80,10 +80,6 @@ public class AerospikeWriteData {
 		return Optional.ofNullable(version);
 	}
 
-	public boolean hasVersion() {
-		return version != null;
-	}
-
 	public void setVersion(Integer version) {
 		this.version = version;
 	}

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -168,7 +168,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 
 		AerospikeWriteData data = writeData(document);
 
-		if (data.hasVersion()) {
+		AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(document.getClass());
+		if (entity.hasVersionProperty()) {
 			WritePolicy policy = expectGenerationCasAwareSavePolicy(data);
 
 			doPersistWithVersionAndHandleCasError(document, data, policy);
@@ -201,8 +202,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 
 		AerospikeWriteData data = writeData(document);
 		WritePolicy policy = ignoreGenerationSavePolicy(data, RecordExistsAction.CREATE_ONLY);
-
-		if(data.hasVersion()) {
+		AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(document.getClass());
+		if(entity.hasVersionProperty()) {
 			// we are ignoring generation here as insert operation should fail with DuplicateKeyException if key already exists
 			// and we do not mind which initial version is set in the document, BUT we need to update the version value in the original document
 			// also we do not want to handle aerospike error codes as cas aware error codes as we are ignoring generation
@@ -217,7 +218,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 		Assert.notNull(document, "Document must not be null!");
 
 		AerospikeWriteData data = writeData(document);
-		if (data.hasVersion()) {
+		AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(document.getClass());
+		if(entity.hasVersionProperty()) {
 			WritePolicy policy = expectGenerationSavePolicy(data, RecordExistsAction.REPLACE_ONLY);
 
 			doPersistWithVersionAndHandleCasError(document, data, policy);

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
@@ -72,7 +72,8 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
         Assert.notNull(document, "Object to save must not be null!");
 
         AerospikeWriteData data = writeData(document);
-        if (data.hasVersion()) {
+        AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(document.getClass());
+        if (entity.hasVersionProperty()) {
             WritePolicy policy = expectGenerationCasAwareSavePolicy(data);
 
             return doPersistWithVersionAndHandleCasError(document, data, policy);
@@ -96,7 +97,8 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
         AerospikeWriteData data = writeData(document);
         WritePolicy policy = ignoreGenerationSavePolicy(data, RecordExistsAction.CREATE_ONLY);
 
-        if(data.hasVersion()) {
+        AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(document.getClass());
+        if(entity.hasVersionProperty()) {
             // we are ignoring generation here as insert operation should fail with DuplicateKeyException if key already exists
             // and we do not mind which initial version is set in the document, BUT we need to update the version value in the original document
             // also we do not want to handle aerospike error codes as cas aware error codes as we are ignoring generation
@@ -111,7 +113,8 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
         Assert.notNull(document, "Document must not be null!");
 
         AerospikeWriteData data = writeData(document);
-        if (data.hasVersion()) {
+        AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(document.getClass());
+        if(entity.hasVersionProperty()) {
             WritePolicy policy = expectGenerationSavePolicy(data, RecordExistsAction.REPLACE_ONLY);
 
             return doPersistWithVersionAndHandleCasError(document, data, policy);

--- a/src/test/java/org/springframework/data/aerospike/SampleClasses.java
+++ b/src/test/java/org/springframework/data/aerospike/SampleClasses.java
@@ -300,11 +300,11 @@ public class SampleClasses {
 		private String id;
 
 		@Version
-		public long version;
+		public Long version;// do not change to primitive type. See #72 issue
 
 		public String field;
 
-		public VersionedClass(String id, String field, long version) {
+		public VersionedClass(String id, String field, Long version) {
 			this.id = id;
 			this.field = field;
 			this.version = version;

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTest.java
@@ -1038,7 +1038,7 @@ public class MappingAerospikeConverterTest {
 	@Test
 	public void shouldNotWriteVersion() throws Exception {
 		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
-		converter.write(new VersionedClass("id", "data", 42), forWrite);
+		converter.write(new VersionedClass("id", "data", 42L), forWrite);
 
 		assertThat(forWrite.getBins()).containsOnly(
 				new Bin("@user_key", "id"),

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateInsertTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateInsertTests.java
@@ -95,7 +95,7 @@ public class AerospikeTemplateInsertTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void insertsDocumentWithZeroVersionIfThereIsNoDocumentWithSameKey() {
-        VersionedClass document = new VersionedClass(id, "any", 0);
+        VersionedClass document = new VersionedClass(id, "any");
 
         template.insert(document);
 
@@ -104,7 +104,7 @@ public class AerospikeTemplateInsertTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void insertsDocumentWithVersionGreaterThanZeroIfThereIsNoDocumentWithSameKey() {
-        VersionedClass document = new VersionedClass(id, "any", 5);
+        VersionedClass document = new VersionedClass(id, "any", 5L);
 
         template.insert(document);
 
@@ -122,7 +122,7 @@ public class AerospikeTemplateInsertTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void throwsExceptionForDuplicateIdForVersionedDocument() {
-        VersionedClass document = new VersionedClass(id, "any", 5);
+        VersionedClass document = new VersionedClass(id, "any", 5L);
 
         template.insert(document);
         assertThatThrownBy(() -> template.insert(document))

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
@@ -45,7 +45,7 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
         template.save(first);
         blockingAerospikeTestOperations.addNewFieldToSavedDataInAerospike(key);
 
-        template.save(new VersionedClass(id, "foo2", 2));
+        template.save(new VersionedClass(id, "foo2", 2L));
 
         Record record2 = client.get(new Policy(), key);
         assertThat(record2.bins.get("notPresent")).isNull();
@@ -62,30 +62,30 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
     }
 
     @Test
-    public void shouldNotSaveDocumentIfItAlreadyExistsWithZeroVersion() {
-        template.save(new VersionedClass(id, "foo", 0));
+    public void shouldNotSaveDocumentIfItAlreadyExists() {
+        template.save(new VersionedClass(id, "foo"));
 
-        assertThatThrownBy(() -> template.save(new VersionedClass(id, "foo", 0)))
+        assertThatThrownBy(() -> template.save(new VersionedClass(id, "foo")))
                 .isInstanceOf(OptimisticLockingFailureException.class);
     }
 
     @Test
     public void shouldSaveDocumentWithEqualVersion() {
-        template.save(new VersionedClass(id, "foo", 0));
+        template.save(new VersionedClass(id, "foo", 0L));
 
-        template.save(new VersionedClass(id, "foo", 1));
-        template.save(new VersionedClass(id, "foo", 2));
+        template.save(new VersionedClass(id, "foo", 1L));
+        template.save(new VersionedClass(id, "foo", 2L));
     }
 
     @Test
     public void shouldFailSaveNewDocumentWithVersionGreaterThanZero() {
-        assertThatThrownBy(() -> template.save(new VersionedClass(id, "foo", 5)))
+        assertThatThrownBy(() -> template.save(new VersionedClass(id, "foo", 5L)))
                 .isInstanceOf(DataRetrievalFailureException.class);
     }
 
     @Test
     public void shouldUpdateNullField() {
-        VersionedClass versionedClass = new VersionedClass(id, null, 0);
+        VersionedClass versionedClass = new VersionedClass(id, null);
         template.save(versionedClass);
 
         VersionedClass saved = template.findById(id, VersionedClass.class);
@@ -94,7 +94,7 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void shouldUpdateNullFieldForClassWithVersionField() {
-        VersionedClass versionedClass = new VersionedClass(id, "field", 0);
+        VersionedClass versionedClass = new VersionedClass(id, "field");
         template.save(versionedClass);
 
         VersionedClass byId = template.findById(id, VersionedClass.class);
@@ -123,7 +123,7 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void shouldUpdateExistingDocument() {
-        VersionedClass one = new VersionedClass(id, "foo", 0);
+        VersionedClass one = new VersionedClass(id, "foo");
         template.save(one);
 
         template.save(new VersionedClass(id, "foo1", one.version));

--- a/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateInsertTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateInsertTests.java
@@ -80,7 +80,7 @@ public class ReactiveAerospikeTemplateInsertTests extends BaseReactiveIntegratio
 
     @Test
     public void insertsDocumentWithZeroVersionIfThereIsNoDocumentWithSameKey() {
-        VersionedClass document = new VersionedClass(id, "any", 0);
+        VersionedClass document = new VersionedClass(id, "any");
 
         reactiveTemplate.insert(document).block();
 
@@ -89,7 +89,7 @@ public class ReactiveAerospikeTemplateInsertTests extends BaseReactiveIntegratio
 
     @Test
     public void insertsDocumentWithVersionGreaterThanZeroIfThereIsNoDocumentWithSameKey() {
-        VersionedClass document = new VersionedClass(id, "any", 5);
+        VersionedClass document = new VersionedClass(id, "any", 5L);
 
         reactiveTemplate.insert(document).block();
 
@@ -108,7 +108,7 @@ public class ReactiveAerospikeTemplateInsertTests extends BaseReactiveIntegratio
 
     @Test
     public void throwsExceptionForDuplicateIdForVersionedDocument() {
-        VersionedClass document = new VersionedClass(id, "any", 5);
+        VersionedClass document = new VersionedClass(id, "any", 5L);
 
         reactiveTemplate.insert(document).block();
         StepVerifier.create(reactiveTemplate.insert(document))

--- a/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateSaveRelatedTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateSaveRelatedTests.java
@@ -37,33 +37,33 @@ public class ReactiveAerospikeTemplateSaveRelatedTests extends BaseReactiveInteg
 
     @Test(expected = OptimisticLockingFailureException.class)
     public void save_shouldNotSaveDocumentIfItAlreadyExistsWithZeroVersion() {
-        reactiveTemplate.save(new VersionedClass(id, "foo", 0)).block();
-        reactiveTemplate.save(new VersionedClass(id, "foo", 0)).block();
+        reactiveTemplate.save(new VersionedClass(id, "foo", 0L)).block();
+        reactiveTemplate.save(new VersionedClass(id, "foo", 0L)).block();
     }
 
     @Test
     public void save_shouldSaveDocumentWithEqualVersion() {
-        reactiveTemplate.save(new VersionedClass(id, "foo", 0)).block();
+        reactiveTemplate.save(new VersionedClass(id, "foo")).block();
 
-        reactiveTemplate.save(new VersionedClass(id, "foo", 1)).block();
-        reactiveTemplate.save(new VersionedClass(id, "foo", 2)).block();
+        reactiveTemplate.save(new VersionedClass(id, "foo", 1L)).block();
+        reactiveTemplate.save(new VersionedClass(id, "foo", 2L)).block();
     }
 
     @Test(expected = DataRetrievalFailureException.class)
     public void save_shouldFailSaveNewDocumentWithVersionGreaterThanZero() {
-        reactiveTemplate.save(new VersionedClass(id, "foo", 5)).block();
+        reactiveTemplate.save(new VersionedClass(id, "foo", 5L)).block();
     }
 
     @Test
     public void save_shouldUpdateNullField() {
-        VersionedClass versionedClass = new VersionedClass(id, null, 0);
+        VersionedClass versionedClass = new VersionedClass(id, null);
         VersionedClass saved = reactiveTemplate.save(versionedClass).block();
         reactiveTemplate.save(saved).block();
     }
 
     @Test
     public void save_shouldUpdateNullFieldForClassWithVersionField() {
-        VersionedClass versionedClass = new VersionedClass(id, "field", 0);
+        VersionedClass versionedClass = new VersionedClass(id, "field");
         reactiveTemplate.save(versionedClass).block();
 
         assertThat(findById(id, VersionedClass.class).getField()).isEqualTo("field");
@@ -89,7 +89,7 @@ public class ReactiveAerospikeTemplateSaveRelatedTests extends BaseReactiveInteg
 
     @Test
     public void save_shouldUpdateExistingDocument() {
-        VersionedClass one = new VersionedClass(id, "foo", 0);
+        VersionedClass one = new VersionedClass(id, "foo");
         reactiveTemplate.save(one).block();
 
         reactiveTemplate.save(new VersionedClass(id, "foo1", one.version)).block();
@@ -188,7 +188,7 @@ public class ReactiveAerospikeTemplateSaveRelatedTests extends BaseReactiveInteg
         reactiveTemplate.save(first).block();
         blockingAerospikeTestOperations.addNewFieldToSavedDataInAerospike(key);
 
-        reactiveTemplate.save(new VersionedClass(id, "foo2", 2)).block();
+        reactiveTemplate.save(new VersionedClass(id, "foo2", 2L)).block();
 
         StepVerifier.create(reactorClient.get(new Policy(), key))
                 .assertNext(keyRecord -> {


### PR DESCRIPTION
fixes #72