### PR TITLE
fixes gh-115

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
+++ b/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
@@ -3,6 +3,7 @@ package org.springframework.data.aerospike.config;
 import com.aerospike.client.AerospikeClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
 import org.springframework.data.aerospike.core.AerospikeExceptionTranslator;
 import org.springframework.data.aerospike.core.AerospikeTemplate;
@@ -38,7 +39,7 @@ public abstract class AbstractAerospikeDataConfiguration extends AerospikeDataCo
 
     @Bean
     public AerospikePersistenceEntityIndexCreator aerospikePersistenceEntityIndexCreator(AerospikeMappingContext aerospikeMappingContext,
-                                                                                         AerospikeTemplate template) {
+                                                                                         @Lazy AerospikeTemplate template) {
         return new AerospikePersistenceEntityIndexCreator(aerospikeMappingContext, template);
     }
 

--- a/src/main/java/org/springframework/data/aerospike/config/AbstractReactiveAerospikeDataConfiguration.java
+++ b/src/main/java/org/springframework/data/aerospike/config/AbstractReactiveAerospikeDataConfiguration.java
@@ -6,6 +6,7 @@ import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.client.reactor.AerospikeReactorClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
 import org.springframework.data.aerospike.core.AerospikeExceptionTranslator;
 import org.springframework.data.aerospike.core.ReactiveAerospikeTemplate;
@@ -70,7 +71,7 @@ public abstract class AbstractReactiveAerospikeDataConfiguration extends Aerospi
     @Bean
     public ReactiveAerospikePersistenceEntityIndexCreator aerospikePersistenceEntityIndexCreator(
             AerospikeMappingContext aerospikeMappingContext,
-            ReactiveAerospikeTemplate template) {
+            @Lazy ReactiveAerospikeTemplate template) {
         return new ReactiveAerospikePersistenceEntityIndexCreator(aerospikeMappingContext, template);
     }
 }

--- a/src/main/java/org/springframework/data/aerospike/index/BaseAerospikePersistenceEntityIndexCreator.java
+++ b/src/main/java/org/springframework/data/aerospike/index/BaseAerospikePersistenceEntityIndexCreator.java
@@ -20,21 +20,26 @@ package org.springframework.data.aerospike.index;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.data.aerospike.mapping.AerospikeMappingContext;
 import org.springframework.data.aerospike.mapping.BasicAerospikePersistentEntity;
 import org.springframework.data.mapping.context.MappingContextEvent;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Taras Danylchuk
  */
 @Slf4j
 @RequiredArgsConstructor
-public abstract class BaseAerospikePersistenceEntityIndexCreator implements ApplicationListener<MappingContextEvent<?, ?>> {
+public abstract class BaseAerospikePersistenceEntityIndexCreator implements ApplicationListener<MappingContextEvent<?, ?>> , SmartLifecycle {
 
     private final AerospikeIndexResolver aerospikeIndexDetector = new AerospikeIndexResolver();
     private final AerospikeMappingContext aerospikeMappingContext;
+    private final Set<AerospikeIndexDefinition> initialIndexes = new HashSet<>();
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
 
     @Override
     public void onApplicationEvent(MappingContextEvent<?, ?> event) {
@@ -49,11 +54,31 @@ public abstract class BaseAerospikePersistenceEntityIndexCreator implements Appl
         BasicAerospikePersistentEntity<?> persistentEntity = (BasicAerospikePersistentEntity<?>) event.getPersistentEntity();
         Set<AerospikeIndexDefinition> indexes = aerospikeIndexDetector.detectIndexes(persistentEntity);
         if (!indexes.isEmpty()) {
+            if (!initialized.get()) {
+                //gh-115: prevent creating indexes on startup phase when aerospike template have not been created yet
+                initialIndexes.addAll(indexes);
+                return;
+            }
             log.debug("Creating {} indexes for entity[{}]...", indexes, event.getPersistentEntity().getName());
             installIndexes(indexes);
         }
     }
 
+    @Override
+    public void start() {
+        initialized.set(true);
+        installIndexes(initialIndexes);
+        initialIndexes.clear();
+    }
+
     protected abstract void installIndexes(Set<AerospikeIndexDefinition> indexes);
 
+    @Override
+    public void stop() {
+    }
+
+    @Override
+    public boolean isRunning() {
+        return initialized.get();
+    }
 }

--- a/src/test/java/org/springframework/data/aerospike/config/ConfigPackageDocument.java
+++ b/src/test/java/org/springframework/data/aerospike/config/ConfigPackageDocument.java
@@ -1,0 +1,18 @@
+package org.springframework.data.aerospike.config;
+
+import com.aerospike.client.query.IndexType;
+import lombok.Value;
+import org.springframework.data.aerospike.annotation.Indexed;
+import org.springframework.data.aerospike.mapping.Document;
+import org.springframework.data.annotation.Id;
+
+@Value
+@Document(collection = "config-package-document-set")
+public class ConfigPackageDocument {
+
+    @Id
+    String id;
+
+    @Indexed(type = IndexType.STRING, name = "config-package-document-index")
+    String indexedField;
+}

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateIndexTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateIndexTests.java
@@ -11,7 +11,6 @@ import org.springframework.data.aerospike.IndexAlreadyExistsException;
 import org.springframework.data.aerospike.IndexNotFoundException;
 import org.springframework.data.aerospike.mapping.Document;
 import org.springframework.data.aerospike.query.model.Index;
-import org.springframework.data.aerospike.sample.AutoIndexedDocument;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -139,9 +138,7 @@ public class AerospikeTemplateIndexTests extends BaseBlockingIntegrationTests {
 
     @Test
     void indexedAnnotation_createsIndexes() {
-        String setName = template.getSetName(AutoIndexedDocument.class);
-
-        AutoIndexedDocumentAssert.assertIndexesCreated(additionalAerospikeTestOperations, namespace, setName);
+        AutoIndexedDocumentAssert.assertIndexesCreated(additionalAerospikeTestOperations, namespace);
     }
 
     @Value

--- a/src/test/java/org/springframework/data/aerospike/core/AutoIndexedDocumentAssert.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AutoIndexedDocumentAssert.java
@@ -13,7 +13,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @UtilityClass
 public class AutoIndexedDocumentAssert {
 
-    public void assertIndexesCreated(AdditionalAerospikeTestOperations operations, String namespace, String setName) {
+    public void assertIndexesCreated(AdditionalAerospikeTestOperations operations, String namespace) {
+        assertAutoIndexedDocumentIndexesCreated(operations, namespace);
+        assertConfigPackageDocumentIndexesCreated(operations, namespace);
+    }
+
+    public void assertAutoIndexedDocumentIndexesCreated(AdditionalAerospikeTestOperations operations, String namespace) {
+        String setName = "auto-indexed-set";
         List<Index> indexes = operations.getIndexes(setName);
 
         assertThat(indexes).containsExactlyInAnyOrder(
@@ -27,6 +33,15 @@ public class AutoIndexedDocumentAssert {
                 index(namespace, setName, setName + "_mapOfStrVals_string_mapvalues", "mapOfStrVals", IndexType.STRING, IndexCollectionType.MAPVALUES),
                 index(namespace, setName, setName + "_mapOfIntKeys_numeric_mapkeys", "mapOfIntKeys", IndexType.NUMERIC, IndexCollectionType.MAPKEYS),
                 index(namespace, setName, setName + "_mapOfIntVals_numeric_mapvalues", "mapOfIntVals", IndexType.NUMERIC, IndexCollectionType.MAPVALUES)
+        );
+    }
+
+    public void assertConfigPackageDocumentIndexesCreated(AdditionalAerospikeTestOperations operations, String namespace) {
+        String setName = "config-package-document-set";
+        List<Index> indexes = operations.getIndexes(setName);
+
+        assertThat(indexes).containsExactlyInAnyOrder(
+                index(namespace, setName, "config-package-document-index", "indexedField", IndexType.STRING, IndexCollectionType.DEFAULT)
         );
     }
 

--- a/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateIndexTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateIndexTests.java
@@ -121,9 +121,7 @@ public class ReactiveAerospikeTemplateIndexTests extends BaseReactiveIntegration
 
     @Test
     void indexedAnnotation_createsIndexes() {
-        String setName = reactiveTemplate.getSetName(AutoIndexedDocument.class);
-
-        AutoIndexedDocumentAssert.assertIndexesCreated(additionalAerospikeTestOperations, namespace, setName);
+        AutoIndexedDocumentAssert.assertIndexesCreated(additionalAerospikeTestOperations, namespace);
     }
 
     private boolean indexExists(String indexName, String binName) {


### PR DESCRIPTION
Root cause:
spring data scans base package of configuration for entities to be added to mapping context at template bean creation phase.
Since template is needed for index creation, entity index creator fails to create annotation based indexes on circular dependency to template.

Resolution summary:
accumulate indexes which comes before context is being inited and create all in batch after context is up and all beans are created. Futher creations will be based on persistence entity applicaton event