### PR TITLE
Upgrade Spring Cloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring-boot-starter-test.version>2.4.3</spring-boot-starter-test.version>
-        <spring-cloud-starter.version>2.2.7.RELEASE</spring-cloud-starter.version>
+        <spring-cloud-starter-bootstrap.version>3.0.1</spring-cloud-starter-bootstrap.version>
         <embedded-aerospike.version>2.0.3</embedded-aerospike.version>
         <awaitility.version>4.0.3</awaitility.version>
         <blockhound.version>1.0.4.RELEASE</blockhound.version>
@@ -244,8 +244,8 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter</artifactId>
-            <version>${spring-cloud-starter.version}</version>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+            <version>${spring-cloud-starter-bootstrap.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Upgrade spring-cloud-starter 2.2.7.RELEASE to spring-cloud-starter-**bootstrap** 3.0.1.

"testcontainers-spring-boot project migrated to Spring Boot 2.4 in 2.0.0 version. Please note, that in order to use this project with Spring Boot 2.4, you need to use spring-cloud-starter-bootstrap dependency. For earlier Spring Boot (prior to 2.4) users — you need to use spring-cloud-starter dependency instead."

Source:
https://github.com/Playtika/testcontainers-spring-boot#how-to-use