### PR TITLE
Upgrade Aerospike clients dependencies + remove deprecations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
     <properties>
         <source.level>1.8</source.level>
-        <aerospike>5.0.5</aerospike>
-        <aerospike-reactor>5.0.3</aerospike-reactor>
+        <aerospike>5.1.0</aerospike>
+        <aerospike-reactor>5.0.7</aerospike-reactor>
 
         <springdata.commons>2.4.6</springdata.commons>
         <springdata.keyvalue>2.4.6</springdata.keyvalue>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <source.level>1.8</source.level>
-        <aerospike>5.1.0</aerospike>
+        <aerospike>5.1.2</aerospike>
         <aerospike-reactor>5.0.7</aerospike-reactor>
 
         <springdata.commons>2.4.6</springdata.commons>

--- a/src/main/java/org/springframework/data/aerospike/config/ReadPolicyFactoryBean.java
+++ b/src/main/java/org/springframework/data/aerospike/config/ReadPolicyFactoryBean.java
@@ -18,7 +18,6 @@ package org.springframework.data.aerospike.config;
 import org.springframework.beans.factory.FactoryBean;
 
 import com.aerospike.client.policy.Policy;
-import com.aerospike.client.policy.Priority;
 
 /**
  * A {@link FactoryBean} implementation that exposes the setters necessary to configure a read policy via XML.
@@ -71,15 +70,6 @@ public class ReadPolicyFactoryBean implements FactoryBean<Policy> {
 	 */
 	public void setSleepBetweenRetries(int sleepBetweenRetries){
 		this.policy.sleepBetweenRetries = sleepBetweenRetries;
-	}
-
-	/**
-	 * Configures the priority of request relative to other transactions.
-	 * Currently, only used for scans.
-	 * @param priority The priority configuration value.
-	 */
-	public void setPriority(Priority priority){
-		this.policy.priority = priority;
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/aerospike/config/ScanPolicyFactoryBean.java
+++ b/src/main/java/org/springframework/data/aerospike/config/ScanPolicyFactoryBean.java
@@ -44,14 +44,6 @@ public class ScanPolicyFactoryBean extends ReadPolicyFactoryBean {
 	}
 	
 	/**
-	 * Configures termination of scan if cluster in fluctuating state.
-	 * @param failOnClusterChange The failOnClusterChange configuration value.
-	 */
-	public void setFailOnClusterChange(boolean failOnClusterChange){
-		this.policy.failOnClusterChange = failOnClusterChange;
-	}
-	
-	/**
 	 * Indicates if bin data is retrieved. If false, only record digests are retrieved.
 	 * @param includeBinData The includeBinData configuration value.
 	 */
@@ -71,15 +63,6 @@ public class ScanPolicyFactoryBean extends ReadPolicyFactoryBean {
 	 */
 	public void setMaxConcurrentNodes(int maxConcurrentNodes){
 		this.policy.maxConcurrentNodes = maxConcurrentNodes;
-	}
-	
-	/**
-	 * Configure the percent of data to scan.  Valid integer range is 1 to 100.
-	 * Default is 100.
-	 * @param scanPercent The scanPercent configuration value.
-	 */
-	public void setScanPercent(int scanPercent){
-		this.policy.scanPercent = scanPercent;
 	}
 
 	/* 


### PR DESCRIPTION
1. Remove deprecated usages:
a. ScanPolicy: scanPercent and failOnClusterChange properties.
b. Policy: priority property.

2. Upgrade both reactive and non-reactive Aerospike java clients.