### PR TITLE
Deprecate old java date times (Joda and java.util) use java.time instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,11 +168,6 @@
                 <version>${aerospike-reactor}</version>
             </dependency>
             <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${jodatime}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
@@ -215,12 +210,6 @@
         <dependency>
             <groupId>com.aerospike</groupId>
             <artifactId>aerospike-reactor-client</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/src/main/java/org/springframework/data/aerospike/convert/DateConverters.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/DateConverters.java
@@ -13,25 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.aerospike.convert;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-
-import org.joda.time.DateMidnight;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalDateTime;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
-import org.springframework.util.ClassUtils;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Out of the box conversions for java dates and calendars.
@@ -43,191 +36,41 @@ public final class DateConverters {
   private DateConverters() {
   }
 
-  private static final boolean JODA_TIME_IS_PRESENT = ClassUtils.isPresent("org.joda.time.LocalDate", null);
-
   /**
    * Returns all converters by this class that can be registered.
    *
    * @return the list of converters to register.
    */
   public static Collection<Converter<?, ?>> getConvertersToRegister() {
-    List<Converter<?, ?>> converters = new ArrayList<Converter<?, ?>>();
+    List<Converter<?, ?>> converters = new ArrayList<>();
 
-    converters.add(DateToLongConverter.INSTANCE);
-    converters.add(CalendarToLongConverter.INSTANCE);
-    converters.add(NumberToDateConverter.INSTANCE);
-    converters.add(NumberToCalendarConverter.INSTANCE);
     converters.add(Java8LocalDateTimeToLongConverter.INSTANCE);
     converters.add(NumberToJava8LocalDateTimeConverter.INSTANCE);
-
-    if (JODA_TIME_IS_PRESENT) {
-      converters.add(LocalDateToLongConverter.INSTANCE);
-      converters.add(LocalDateTimeToLongConverter.INSTANCE);
-      converters.add(DateTimeToLongConverter.INSTANCE);
-      converters.add(DateMidnightToLongConverter.INSTANCE);
-      converters.add(NumberToLocalDateConverter.INSTANCE);
-      converters.add(NumberToLocalDateTimeConverter.INSTANCE);
-      converters.add(NumberToDateTimeConverter.INSTANCE);
-      converters.add(NumberToDateMidnightConverter.INSTANCE);
-    }
 
     return converters;
   }
 
   @WritingConverter
-  public enum DateToLongConverter implements Converter<Date, Long> {
-    INSTANCE;
-
-    @Override
-    public Long convert(Date source) {
-      return source == null ? null : source.getTime();
-    }
-  }
-
-  @WritingConverter
-  public enum Java8LocalDateTimeToLongConverter implements Converter<java.time.LocalDateTime, Long> {
-    INSTANCE;
-
-    @Override
-    public Long convert(java.time.LocalDateTime source) {
-      return source == null ? null : source.atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
-    }
-  }
-
-  @WritingConverter
-  public enum CalendarToLongConverter implements Converter<Calendar, Long> {
-    INSTANCE;
-
-    @Override
-    public Long convert(Calendar source) {
-      return source == null ? null : source.getTimeInMillis() / 1000;
-    }
-  }
-
-  @ReadingConverter
-  public enum NumberToDateConverter implements Converter<Number, Date> {
-    INSTANCE;
-
-    @Override
-    public Date convert(Number source) {
-      if (source == null) {
-        return null;
-      }
-
-      Date date = new Date();
-      date.setTime(source.longValue());
-      return date;
-    }
-  }
-
-  @ReadingConverter
-  public enum NumberToJava8LocalDateTimeConverter implements Converter<Number, java.time.LocalDateTime> {
-    INSTANCE;
-
-    @Override
-    public java.time.LocalDateTime convert(Number source) {
-      if (source == null) {
-        return null;
-      }
-
-      return java.time.LocalDateTime.ofInstant(Instant.ofEpochMilli(source.longValue()), ZoneOffset.UTC);
-    }
-  }
-
-  @ReadingConverter
-  public enum NumberToCalendarConverter implements Converter<Number, Calendar> {
-    INSTANCE;
-
-    @Override
-    public Calendar convert(Number source) {
-      if (source == null) {
-        return null;
-      }
-
-      Calendar calendar = Calendar.getInstance();
-      calendar.setTimeInMillis(source.longValue() * 1000);
-      return calendar;
-    }
-  }
-
-  @WritingConverter
-  public enum LocalDateToLongConverter implements Converter<LocalDate, Long> {
-    INSTANCE;
-
-    @Override
-    public Long convert(LocalDate source) {
-      return source == null ? null : source.toDate().getTime();
-    }
-  }
-
-  @WritingConverter
-  public enum LocalDateTimeToLongConverter implements Converter<LocalDateTime, Long> {
+  public enum Java8LocalDateTimeToLongConverter implements Converter<LocalDateTime, Long> {
     INSTANCE;
 
     @Override
     public Long convert(LocalDateTime source) {
-      return source == null ? null : source.toDate().getTime();
-    }
-  }
-
-  @WritingConverter
-  public enum DateTimeToLongConverter implements Converter<DateTime, Long> {
-    INSTANCE;
-
-    @Override
-    public Long convert(DateTime source) {
-      return source == null ? null : source.toDate().getTime();
-    }
-  }
-
-  @WritingConverter
-  public enum DateMidnightToLongConverter implements Converter<DateMidnight, Long> {
-    INSTANCE;
-
-    @Override
-    public Long convert(DateMidnight source) {
-      return source == null ? null : source.toDate().getTime();
+      return source == null ? null : source.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
     }
   }
 
   @ReadingConverter
-  public enum NumberToLocalDateConverter implements Converter<Number, LocalDate> {
-    INSTANCE;
-
-    @Override
-    public LocalDate convert(Number source) {
-      return source == null ? null : new LocalDate(source.longValue());
-    }
-  }
-
-  @ReadingConverter
-  public enum NumberToLocalDateTimeConverter implements Converter<Number, LocalDateTime> {
+  public enum NumberToJava8LocalDateTimeConverter implements Converter<Number, LocalDateTime> {
     INSTANCE;
 
     @Override
     public LocalDateTime convert(Number source) {
-      return source == null ? null : new LocalDateTime(source.longValue());
+      if (source == null) {
+        return null;
+      }
+
+      return LocalDateTime.ofInstant(Instant.ofEpochMilli(source.longValue()), ZoneId.systemDefault());
     }
   }
-
-  @ReadingConverter
-  public enum NumberToDateTimeConverter implements Converter<Number, DateTime> {
-    INSTANCE;
-
-    @Override
-    public DateTime convert(Number source) {
-      return source == null ? null : new DateTime(source.longValue());
-    }
-  }
-
-  @ReadingConverter
-  public enum NumberToDateMidnightConverter implements Converter<Number, DateMidnight> {
-    INSTANCE;
-
-    @Override
-    public DateMidnight convert(Number source) {
-      return source == null ? null : new DateMidnight(source.longValue());
-    }
-  }
-
 }

--- a/src/test/java/org/springframework/data/aerospike/SampleClasses.java
+++ b/src/test/java/org/springframework/data/aerospike/SampleClasses.java
@@ -17,14 +17,7 @@ package org.springframework.data.aerospike;
 
 import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-import lombok.Value;
-import org.joda.time.DateTime;
+import lombok.*;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.aerospike.annotation.Expiration;
 import org.springframework.data.aerospike.convert.AerospikeReadData;
@@ -39,15 +32,8 @@ import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.springframework.data.aerospike.SampleClasses.SimpleClass.SIMPLESET;
@@ -59,10 +45,10 @@ public class SampleClasses {
 	public static final int EXPIRATION_ONE_SECOND = 1;
 	public static final int EXPIRATION_ONE_MINUTE = 60;
 
-	static interface SomeInterface {
+	interface SomeInterface {
 	}
 
-	public static enum TYPES {
+	public enum TYPES {
 		FIRST(1), SECOND(2), THIRD(3);
 		final int id;
 
@@ -317,7 +303,7 @@ public class SampleClasses {
 		public String id;
 	}
 
-	public static interface Contact {
+	public interface Contact {
 
 	}
 
@@ -534,7 +520,7 @@ public class SampleClasses {
 		private String id;
 
 		@Expiration(unixTime = true)
-		private DateTime expiration;
+		private LocalDateTime expiration;
 	}
 
 	@Document(expirationExpression = "${expirationProperty}")
@@ -569,7 +555,7 @@ public class SampleClasses {
 		private String id;
 
 		@Expiration(unixTime = true)
-		private DateTime expiration;
+		private LocalDateTime expiration;
 
 		private int intField;
 	}

--- a/src/test/java/org/springframework/data/aerospike/SampleClasses.java
+++ b/src/test/java/org/springframework/data/aerospike/SampleClasses.java
@@ -32,6 +32,7 @@ import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -71,7 +72,7 @@ public class SampleClasses {
 		final float field4;
 		final double field5;
 		final boolean field6;
-		final Date field7;
+		final LocalDate field7;
 		final TYPES field8;
 		final Set<String> field9;
 		final Set<Set<String>> field10;

--- a/src/test/java/org/springframework/data/aerospike/SampleClasses.java
+++ b/src/test/java/org/springframework/data/aerospike/SampleClasses.java
@@ -32,7 +32,6 @@ import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -72,7 +71,7 @@ public class SampleClasses {
 		final float field4;
 		final double field5;
 		final boolean field6;
-		final LocalDate field7;
+		final LocalDateTime field7;
 		final TYPES field8;
 		final Set<String> field9;
 		final Set<Set<String>> field10;

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTest.java
@@ -20,7 +20,6 @@ import com.aerospike.client.Key;
 import com.aerospike.client.Record;
 import com.aerospike.client.Value;
 import org.assertj.core.data.Offset;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.aerospike.SampleClasses;
 import org.springframework.data.aerospike.SampleClasses.AerospikeReadDataToUserConverter;
@@ -40,6 +39,7 @@ import org.springframework.data.aerospike.SampleClasses.VersionedClass;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -179,14 +179,14 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 		AerospikeReadData readData = AerospikeReadData.forRead(key, record);
 		DocumentWithUnixTimeExpiration forRead = converter.read(DocumentWithUnixTimeExpiration.class, readData);
 
-		DateTime actual = forRead.getExpiration();
-		DateTime expected = DateTime.now().plusSeconds(EXPIRATION_ONE_MINUTE);
-		assertThat(actual.getMillis()).isCloseTo(expected.getMillis(), Offset.offset(100L));
+		LocalDateTime actual = forRead.getExpiration();
+		LocalDateTime expected = LocalDateTime.now().plusSeconds(EXPIRATION_ONE_MINUTE);
+		assertThat(actual.getNano()).isCloseTo(expected.getNano(), Offset.offset(100));
 	}
 
 	@Test
 	public void shouldWriteUnixTimeExpirationFieldValue() {
-		DateTime unixTimeExpiration = DateTime.now().plusSeconds(EXPIRATION_ONE_MINUTE);
+		LocalDateTime unixTimeExpiration = LocalDateTime.now().plusSeconds(EXPIRATION_ONE_MINUTE);
 		DocumentWithUnixTimeExpiration document = new DocumentWithUnixTimeExpiration("docId", unixTimeExpiration);
 
 		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
@@ -197,7 +197,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 
 	@Test
 	public void shouldFailWithExpirationFromThePast() {
-		DateTime expirationFromThePast = DateTime.now().minusSeconds(EXPIRATION_ONE_MINUTE);
+		LocalDateTime expirationFromThePast = LocalDateTime.now().minusSeconds(EXPIRATION_ONE_MINUTE);
 		DocumentWithUnixTimeExpiration document = new DocumentWithUnixTimeExpiration("docId", expirationFromThePast);
 
 		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
@@ -265,9 +265,9 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 		AerospikeReadData forRead = AerospikeReadData.forRead(key, record);
 
 		DocumentWithDefaultConstructor document = converter.read(DocumentWithDefaultConstructor.class, forRead);
-		DateTime actual = document.getExpiration();
-		DateTime expected = DateTime.now().plusSeconds(EXPIRATION_ONE_MINUTE);
-		assertThat(actual.getMillis()).isCloseTo(expected.getMillis(), Offset.offset(100L));
+		LocalDateTime actual = document.getExpiration();
+		LocalDateTime expected = LocalDateTime.now().plusSeconds(EXPIRATION_ONE_MINUTE);
+		assertThat(actual.getNano()).isCloseTo(expected.getNano(), Offset.offset(100));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTypesTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTypesTest.java
@@ -156,7 +156,7 @@ public class MappingAerospikeConverterTypesTest extends BaseMappingAerospikeConv
 	void ObjectWithSimpleFields() {
 		Set<String> field9 = set("val1", "val2");
 		Set<Set<String>> field10 = set(set("1", "2"), set("3", "4"), set());
-		SimpleClass object = new SimpleClass(777L, "abyrvalg", 13, 14L, (float) 15, 16.0, true, Instant.ofEpochMilli(8878888L).atZone(ZoneId.systemDefault()).toLocalDate(),
+		SimpleClass object = new SimpleClass(777L, "abyrvalg", 13, 14L, (float) 15, 16.0, true, Instant.ofEpochMilli(8878888L).atZone(ZoneId.systemDefault()).toLocalDateTime(),
 				TYPES.SECOND, field9, field10, (byte) 1);
 
 		assertWriteAndRead(object, SIMPLESET, 777L,

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTypesTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTypesTest.java
@@ -2,59 +2,17 @@ package org.springframework.data.aerospike.convert;
 
 import com.aerospike.client.Bin;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.aerospike.SampleClasses.Address;
-import org.springframework.data.aerospike.SampleClasses.BigDecimalContainer;
-import org.springframework.data.aerospike.SampleClasses.ClassWithComplexId;
-import org.springframework.data.aerospike.SampleClasses.ClassWithIdField;
-import org.springframework.data.aerospike.SampleClasses.CollectionOfObjects;
-import org.springframework.data.aerospike.SampleClasses.ComplexId;
-import org.springframework.data.aerospike.SampleClasses.ContainerOfCustomFieldNames;
-import org.springframework.data.aerospike.SampleClasses.CustomFieldNames;
-import org.springframework.data.aerospike.SampleClasses.CustomTypeWithCustomType;
-import org.springframework.data.aerospike.SampleClasses.CustomTypeWithListAndMap;
-import org.springframework.data.aerospike.SampleClasses.CustomTypeWithListAndMapImmutable;
-import org.springframework.data.aerospike.SampleClasses.DocumentWithByteArray;
-import org.springframework.data.aerospike.SampleClasses.DocumentWithIntId;
-import org.springframework.data.aerospike.SampleClasses.DocumentWithStringId;
-import org.springframework.data.aerospike.SampleClasses.EnumProperties;
-import org.springframework.data.aerospike.SampleClasses.GenericType;
-import org.springframework.data.aerospike.SampleClasses.ImmutableListAndMap;
-import org.springframework.data.aerospike.SampleClasses.ListOfLists;
-import org.springframework.data.aerospike.SampleClasses.ListOfMaps;
-import org.springframework.data.aerospike.SampleClasses.MapWithCollectionValue;
-import org.springframework.data.aerospike.SampleClasses.MapWithGenericValue;
-import org.springframework.data.aerospike.SampleClasses.MapWithSimpleValue;
-import org.springframework.data.aerospike.SampleClasses.Name;
-import org.springframework.data.aerospike.SampleClasses.NestedMapsWithSimpleValue;
-import org.springframework.data.aerospike.SampleClasses.Person;
-import org.springframework.data.aerospike.SampleClasses.SetWithSimpleValue;
-import org.springframework.data.aerospike.SampleClasses.SimpleClass;
-import org.springframework.data.aerospike.SampleClasses.SimpleClassWithPersistenceConstructor;
-import org.springframework.data.aerospike.SampleClasses.SortedMapWithSimpleValue;
-import org.springframework.data.aerospike.SampleClasses.Street;
-import org.springframework.data.aerospike.SampleClasses.TYPES;
-import org.springframework.data.aerospike.SampleClasses.User;
+import org.springframework.data.aerospike.SampleClasses.*;
 import org.springframework.data.aerospike.assertions.KeyAssert;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.data.aerospike.AsCollections.list;
-import static org.springframework.data.aerospike.AsCollections.of;
-import static org.springframework.data.aerospike.AsCollections.set;
+import static org.springframework.data.aerospike.AsCollections.*;
 import static org.springframework.data.aerospike.SampleClasses.SimpleClass.SIMPLESET;
 import static org.springframework.data.aerospike.SampleClasses.SimpleClassWithPersistenceConstructor.SIMPLESET2;
 import static org.springframework.data.aerospike.SampleClasses.User.SIMPLESET3;
@@ -198,7 +156,7 @@ public class MappingAerospikeConverterTypesTest extends BaseMappingAerospikeConv
 	void ObjectWithSimpleFields() {
 		Set<String> field9 = set("val1", "val2");
 		Set<Set<String>> field10 = set(set("1", "2"), set("3", "4"), set());
-		SimpleClass object = new SimpleClass(777L, "abyrvalg", 13, 14L, (float) 15, 16.0, true, new Date(8878888),
+		SimpleClass object = new SimpleClass(777L, "abyrvalg", 13, 14L, (float) 15, 16.0, true, Instant.ofEpochMilli(8878888L).atZone(ZoneId.systemDefault()).toLocalDate(),
 				TYPES.SECOND, field9, field10, (byte) 1);
 
 		assertWriteAndRead(object, SIMPLESET, 777L,

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeExpirationTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeExpirationTests.java
@@ -19,27 +19,23 @@ import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 import com.aerospike.client.Record;
 import org.assertj.core.data.Offset;
-import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.aerospike.BaseBlockingIntegrationTests;
-import org.springframework.data.aerospike.SampleClasses.DocumentWithDefaultConstructor;
-import org.springframework.data.aerospike.SampleClasses.DocumentWithExpiration;
-import org.springframework.data.aerospike.SampleClasses.DocumentWithExpirationAnnotation;
-import org.springframework.data.aerospike.SampleClasses.DocumentWithExpirationOneDay;
-import org.springframework.data.aerospike.SampleClasses.DocumentWithUnixTimeExpiration;
+import org.springframework.data.aerospike.SampleClasses.*;
+
+import java.time.LocalDateTime;
 
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Offset.offset;
-import static org.springframework.data.aerospike.SampleClasses.DocumentWithExpirationAnnotationAndPersistenceConstructor;
+import static org.springframework.data.aerospike.AwaitilityUtils.awaitTenSecondsUntil;
+import static org.springframework.data.aerospike.AwaitilityUtils.awaitTwoSecondsUntil;
 import static org.springframework.data.aerospike.utility.AerospikeExpirationPolicy.DO_NOT_UPDATE_EXPIRATION;
 import static org.springframework.data.aerospike.utility.AerospikeExpirationPolicy.NEVER_EXPIRE;
-import static org.springframework.data.aerospike.AwaitilityUtils.awaitTwoSecondsUntil;
-import static org.springframework.data.aerospike.AwaitilityUtils.awaitTenSecondsUntil;
 
 public class AerospikeExpirationTests extends BaseBlockingIntegrationTests {
 
@@ -52,7 +48,7 @@ public class AerospikeExpirationTests extends BaseBlockingIntegrationTests {
     public void shouldAddValuesMapAndExpire() {
         DocumentWithDefaultConstructor document = new DocumentWithDefaultConstructor();
         document.setId(id);
-        document.setExpiration(DateTime.now().plusSeconds(1));
+        document.setExpiration(LocalDateTime.now().plusSeconds(1));
 
         template.add(document, singletonMap("intField", 10L));
 
@@ -70,7 +66,7 @@ public class AerospikeExpirationTests extends BaseBlockingIntegrationTests {
     public void shouldAddValueAndExpire() {
         DocumentWithDefaultConstructor document = new DocumentWithDefaultConstructor();
         document.setId(id);
-        document.setExpiration(DateTime.now().plusSeconds(1));
+        document.setExpiration(LocalDateTime.now().plusSeconds(1));
 
         template.add(document, "intField", 10L);
 
@@ -86,7 +82,7 @@ public class AerospikeExpirationTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void shouldExpireBasedOnUnixTimeValue() {
-        template.insert(new DocumentWithUnixTimeExpiration(id, DateTime.now().plusSeconds(1)));
+        template.insert(new DocumentWithUnixTimeExpiration(id, LocalDateTime.now().plusSeconds(1)));
 
         awaitTwoSecondsUntil(() ->
                 assertThat(template.findById(id, DocumentWithUnixTimeExpiration.class)).isNotNull()

--- a/src/test/java/org/springframework/data/aerospike/utility/TimeUtilsTest.java
+++ b/src/test/java/org/springframework/data/aerospike/utility/TimeUtilsTest.java
@@ -4,6 +4,7 @@ import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.data.aerospike.SampleClasses.EXPIRATION_ONE_SECOND;
@@ -12,15 +13,15 @@ public class TimeUtilsTest {
 
     @Test
     public void shouldConvertOffsetInSecondsToUnixTime() {
-        int expected = LocalDateTime.now().plusSeconds(EXPIRATION_ONE_SECOND).getNano();
+        long nowPlusOneSecond = LocalDateTime.now().plusSeconds(EXPIRATION_ONE_SECOND).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
         long actual = TimeUtils.offsetInSecondsToUnixTime(EXPIRATION_ONE_SECOND);
 
-        assertThat(actual).isCloseTo(expected, Offset.offset(100L));
+        assertThat(actual).isCloseTo(nowPlusOneSecond, Offset.offset(100L));
     }
 
     @Test
     public void shouldConvertUnixTimeToOffsetInSeconds() {
-        int nowPlusOneSecond = LocalDateTime.now().plusSeconds(EXPIRATION_ONE_SECOND).getNano();
+        long nowPlusOneSecond = LocalDateTime.now().plusSeconds(EXPIRATION_ONE_SECOND).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
         int actual = TimeUtils.unixTimeToOffsetInSeconds(nowPlusOneSecond);
 
         assertThat(actual).isEqualTo(EXPIRATION_ONE_SECOND);

--- a/src/test/java/org/springframework/data/aerospike/utility/TimeUtilsTest.java
+++ b/src/test/java/org/springframework/data/aerospike/utility/TimeUtilsTest.java
@@ -1,8 +1,9 @@
 package org.springframework.data.aerospike.utility;
 
 import org.assertj.core.data.Offset;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.data.aerospike.SampleClasses.EXPIRATION_ONE_SECOND;
@@ -11,7 +12,7 @@ public class TimeUtilsTest {
 
     @Test
     public void shouldConvertOffsetInSecondsToUnixTime() {
-        long expected = DateTime.now().plusSeconds(EXPIRATION_ONE_SECOND).getMillis();
+        int expected = LocalDateTime.now().plusSeconds(EXPIRATION_ONE_SECOND).getNano();
         long actual = TimeUtils.offsetInSecondsToUnixTime(EXPIRATION_ONE_SECOND);
 
         assertThat(actual).isCloseTo(expected, Offset.offset(100L));
@@ -19,7 +20,7 @@ public class TimeUtilsTest {
 
     @Test
     public void shouldConvertUnixTimeToOffsetInSeconds() {
-        long nowPlusOneSecond = DateTime.now().plusSeconds(EXPIRATION_ONE_SECOND).getMillis();
+        int nowPlusOneSecond = LocalDateTime.now().plusSeconds(EXPIRATION_ONE_SECOND).getNano();
         int actual = TimeUtils.unixTimeToOffsetInSeconds(nowPlusOneSecond);
 
         assertThat(actual).isEqualTo(EXPIRATION_ONE_SECOND);


### PR DESCRIPTION
Deprecate old java date times (Joda and java.util) and replace them with Java8 time (java.time).

* Modify java.time converter from UTC to ZoneId.systemDefault() to be aligned with previous logic (of Joda time LocalDate).