### PR TITLE
Bump dependencies versions + support new operation deleteAllById()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
  	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>2.4.6</version>
+		<version>2.5.1</version>
 	</parent>
 
     <properties>
@@ -24,17 +24,17 @@
         <aerospike>5.1.2</aerospike>
         <aerospike-reactor>5.0.7</aerospike-reactor>
 
-        <springdata.commons>2.4.6</springdata.commons>
-        <springdata.keyvalue>2.4.6</springdata.keyvalue>
+        <springdata.commons>2.5.1</springdata.commons>
+        <springdata.keyvalue>2.5.1</springdata.keyvalue>
         <dist.key>DATAAERO</dist.key>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-boot-starter-test.version>2.4.4</spring-boot-starter-test.version>
+        <spring-boot-starter-test.version>2.4.5</spring-boot-starter-test.version>
         <spring-cloud-starter-bootstrap.version>3.0.2</spring-cloud-starter-bootstrap.version>
-        <embedded-aerospike.version>2.0.3</embedded-aerospike.version>
-        <awaitility.version>4.0.3</awaitility.version>
-        <blockhound.version>1.0.4.RELEASE</blockhound.version>
-        <lombok.version>1.18.18</lombok.version>
+        <embedded-aerospike.version>2.0.7</embedded-aerospike.version>
+        <awaitility.version>4.1.0</awaitility.version>
+        <blockhound.version>1.0.6.RELEASE</blockhound.version>
+        <lombok.version>1.18.20</lombok.version>
     </properties>
 
     <licenses>
@@ -311,7 +311,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
         <spring-boot-starter-test.version>2.4.5</spring-boot-starter-test.version>
         <spring-cloud-starter-bootstrap.version>3.0.2</spring-cloud-starter-bootstrap.version>
-        <embedded-aerospike.version>2.0.7</embedded-aerospike.version>
+        <embedded-aerospike.version>2.0.8</embedded-aerospike.version>
         <awaitility.version>4.1.0</awaitility.version>
         <blockhound.version>1.0.6.RELEASE</blockhound.version>
         <lombok.version>1.18.20</lombok.version>

--- a/src/main/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepository.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepository.java
@@ -73,7 +73,8 @@ public class SimpleAerospikeRepository<T, ID> implements AerospikeRepository<T, 
 
 	@Override
 	public void deleteAllById(Iterable<? extends ID> iterable) {
-		throw new UnsupportedOperationException("Method not supported yet.");
+		Assert.notNull(iterable, "The given Iterable must not be null!");
+		iterable.forEach(this::deleteById);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepository.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepository.java
@@ -72,6 +72,11 @@ public class SimpleAerospikeRepository<T, ID> implements AerospikeRepository<T, 
 	}
 
 	@Override
+	public void deleteAllById(Iterable<? extends ID> iterable) {
+		throw new UnsupportedOperationException("Method not supported yet.");
+	}
+
+	@Override
 	public Iterable<T> findAll(Sort sort) {
 		return operations.findAll(sort, entityInformation.getJavaType());
 	}

--- a/src/main/java/org/springframework/data/aerospike/repository/support/SimpleReactiveAerospikeRepository.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/support/SimpleReactiveAerospikeRepository.java
@@ -120,7 +120,10 @@ public class SimpleReactiveAerospikeRepository<T, ID> implements ReactiveAerospi
 
     @Override
     public Mono<Void> deleteAllById(Iterable<? extends ID> iterable) {
-        throw new UnsupportedOperationException("Method not supported yet.");
+        Assert.notNull(iterable, "The given Iterable must not be null!");
+        iterable.forEach(id ->
+                Assert.notNull(id, "The given Iterable of entities must not contain null!"));
+        return Flux.fromIterable(iterable).flatMap(this::deleteById).then();
     }
 
     @Override

--- a/src/main/java/org/springframework/data/aerospike/repository/support/SimpleReactiveAerospikeRepository.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/support/SimpleReactiveAerospikeRepository.java
@@ -119,6 +119,11 @@ public class SimpleReactiveAerospikeRepository<T, ID> implements ReactiveAerospi
     }
 
     @Override
+    public Mono<Void> deleteAllById(Iterable<? extends ID> iterable) {
+        throw new UnsupportedOperationException("Method not supported yet.");
+    }
+
+    @Override
     public Mono<Void> deleteAll(Iterable<? extends T> entities) {
         Assert.notNull(entities, "The given Iterable of entities must not be null!");
         entities.forEach(entity ->

--- a/src/test/java/org/springframework/data/aerospike/repository/reactive/ReactiveAerospikeRepositoryDeleteRelatedTests.java
+++ b/src/test/java/org/springframework/data/aerospike/repository/reactive/ReactiveAerospikeRepositoryDeleteRelatedTests.java
@@ -145,4 +145,12 @@ public class ReactiveAerospikeRepositoryDeleteRelatedTests extends BaseReactiveI
         StepVerifier.create(customerRepo.findById(customer1.getId())).expectNextCount(0).verifyComplete();
         StepVerifier.create(customerRepo.findById(customer2.getId())).expectNextCount(0).verifyComplete();
     }
+
+    @Test
+    public void deleteAllById_ShouldDelete() {
+        customerRepo.deleteAllById(asList(customer1.getId(), customer2.getId())).subscribeOn(Schedulers.parallel()).block();
+
+        StepVerifier.create(customerRepo.findById(customer1.getId())).expectNextCount(0).verifyComplete();
+        StepVerifier.create(customerRepo.findById(customer2.getId())).expectNextCount(0).verifyComplete();
+    }
 }

--- a/src/test/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepositoryTest.java
+++ b/src/test/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepositoryTest.java
@@ -165,6 +165,18 @@ public class SimpleAerospikeRepositoryTest {
 	}
 
 	@Test
+	public void deleteAllById() {
+		List<String> personIds = testPersons.stream()
+				.map(Person::getId)
+				.collect(toList());
+		aerospikeRepository.deleteAllById(personIds);
+
+		verify(operations).delete("one", Person.class);
+		verify(operations).delete("two", Person.class);
+		verify(operations).delete("three", Person.class);
+	}
+
+	@Test
 	public void deleteIterableOfQExtendsT() {
 		aerospikeRepository.deleteAll(testPersons);
 


### PR DESCRIPTION
spring-data-parent from 2.4.6 to 2.5.1.
spring-data-commons from 2.4.6 to 2.5.1.
spring-data-keyvalue from 2.4.6 to 2.5.1.
spring-boot-starter-test from 2.4.4 to 2.4.5.
embedded-aerospike from 2.0.3 to 2.0.7.
awaitility from 4.0.3 to 4.1.0.
blockhound from 1.0.4.RELEASE to 1.0.6.RELEASE.
lombok from 1.18.18 to 1.18.20.