### PR TITLE
Bump dependencies versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,12 @@
  	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 	</parent>
 
     <properties>
         <source.level>1.8</source.level>
-        <aerospike>5.1.2</aerospike>
+        <aerospike>5.1.5</aerospike>
         <aerospike-reactor>5.0.7</aerospike-reactor>
 
         <springdata.commons>2.5.1</springdata.commons>
@@ -29,9 +29,9 @@
         <dist.key>DATAAERO</dist.key>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-boot-starter-test.version>2.4.5</spring-boot-starter-test.version>
-        <spring-cloud-starter-bootstrap.version>3.0.2</spring-cloud-starter-bootstrap.version>
-        <embedded-aerospike.version>2.0.8</embedded-aerospike.version>
+        <spring-boot-starter-test.version>2.5.2</spring-boot-starter-test.version>
+        <spring-cloud-starter-bootstrap.version>3.0.3</spring-cloud-starter-bootstrap.version>
+        <embedded-aerospike.version>2.0.9</embedded-aerospike.version>
         <awaitility.version>4.1.0</awaitility.version>
         <blockhound.version>1.0.6.RELEASE</blockhound.version>
         <lombok.version>1.18.20</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
         <spring-boot-starter-test.version>2.5.2</spring-boot-starter-test.version>
         <spring-cloud-starter-bootstrap.version>3.0.3</spring-cloud-starter-bootstrap.version>
-        <embedded-aerospike.version>2.0.9</embedded-aerospike.version>
+        <embedded-aerospike.version>2.0.10</embedded-aerospike.version>
         <awaitility.version>4.1.0</awaitility.version>
         <blockhound.version>1.0.6.RELEASE</blockhound.version>
         <lombok.version>1.18.20</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <aerospike>5.1.5</aerospike>
         <aerospike-reactor>5.0.7</aerospike-reactor>
 
-        <springdata.commons>2.5.1</springdata.commons>
-        <springdata.keyvalue>2.5.1</springdata.keyvalue>
+        <springdata.commons>2.5.2</springdata.commons>
+        <springdata.keyvalue>2.5.2</springdata.keyvalue>
         <dist.key>DATAAERO</dist.key>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
spring-data-parent from 2.5.1 to 2.5.2.
aerospike-client from 5.1.2 to 5.1.5.
spring-boot-starter-test from 2.4.5 to 2.5.2.
spring-cloud-starter-bootstrap from 3.0.2 to 3.0.3.
embedded-aerospike from 2.0.8 to 2.0.9.