### PR TITLE
Fix javadoc Lombok error

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/config/AerospikeDataSettings.java
+++ b/src/main/java/org/springframework/data/aerospike/config/AerospikeDataSettings.java
@@ -24,4 +24,12 @@ public class AerospikeDataSettings {
 
 	@Builder.Default
 	boolean scansEnabled = false;
+
+	/*
+	 * (non-Javadoc)
+	 * Javadoc is not aware of the code modifications made by Lombok.
+	 * You can fix it with either delombok or by adding a static inner class inside the class that uses the @Builder annotation,
+	 * it will satisfy javadoc and won't interfere with the @Builder annotation's normal behaviour.
+	 */
+	public static class AerospikeDataSettingsBuilder{}
 }


### PR DESCRIPTION
Fix javadoc Lombok error by adding a static class that uses the @Builder annotation to satisfy javadoc and at the same time won't interfere with the @Builder annotation's normal behaviour.