### PR TITLE
Namespace should be determined by the Template's configuration (fixes multiple namespaces scenario)

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/cache/AerospikeCache.java
+++ b/src/main/java/org/springframework/data/aerospike/cache/AerospikeCache.java
@@ -184,7 +184,7 @@ public class AerospikeCache implements Cache {
 	}
 
 	private void serializeAndPut(WritePolicy writePolicy, Object key, Object value) {
-		AerospikeWriteData data = AerospikeWriteData.forWrite();
+		AerospikeWriteData data = AerospikeWriteData.forWrite(getKey(key).namespace);
 		aerospikeConverter.write(value, data);
 		client.put(writePolicy, getKey(key), data.getBinsAsArray());
 	}

--- a/src/main/java/org/springframework/data/aerospike/convert/AerospikeWriteData.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/AerospikeWriteData.java
@@ -51,8 +51,8 @@ public class AerospikeWriteData {
 		this.version = version;
 	}
 
-	public static AerospikeWriteData forWrite() {
-		return new AerospikeWriteData(null, new ArrayList<>(), 0, null);
+	public static AerospikeWriteData forWrite(String namespace) {
+		return new AerospikeWriteData(new Key(namespace, "", ""), new ArrayList<>(), 0, null);
 	}
 
 	public void setKey(Key key) {

--- a/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeConverter.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeConverter.java
@@ -84,5 +84,4 @@ public class MappingAerospikeConverter implements InitializingBean, AerospikeCon
 	public void write(Object source, AerospikeWriteData sink) {
 		writeConverter.write(source, sink);
 	}
-
 }

--- a/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeWriteConverter.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeWriteConverter.java
@@ -79,7 +79,7 @@ public class MappingAerospikeWriteConverter implements EntityWriter<Object, Aero
 			String id = accessor.getProperty(idProperty, String.class);
 			Assert.notNull(id, "Id must not be null!");
 
-			data.setKey(new Key(entity.getNamespace(), entity.getSetName(), id));
+			data.setKey(new Key(data.getKey().namespace, entity.getSetName(), id));
 			data.addBin(USER_KEY, id);
 		}
 

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeKeyValueAdapter.java
@@ -69,7 +69,7 @@ public class AerospikeKeyValueAdapter extends AbstractKeyValueAdapter {
 	 */
 	@Override
 	public Object put(Object id, Object item, String keyspace) {
-		AerospikeWriteData data = AerospikeWriteData.forWrite();
+		AerospikeWriteData data = AerospikeWriteData.forWrite(namespace);
 		converter.write(item, data);
 		client.put(null, data.getKey(), data.getBinsAsArray());
 		return item;

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -197,14 +197,8 @@ abstract class BaseAerospikeTemplate {
     }
 
     <T> AerospikeWriteData writeData(T document) {
-        AerospikeWriteData data = AerospikeWriteData.forWrite();
+        AerospikeWriteData data = AerospikeWriteData.forWrite(getNamespace());
         converter.write(document, data);
-
-        // Override the namespace, the aerospike template's namespace should be used in case its different from the persistent entity's namespace (default)
-        if (!data.getKey().namespace.equals(getNamespace())) {
-            Key newKey = new Key(getNamespace(), data.getKey().setName, data.getKey().userKey);
-            data.setKey(newKey);
-        }
         return data;
     }
 

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -199,6 +199,12 @@ abstract class BaseAerospikeTemplate {
     <T> AerospikeWriteData writeData(T document) {
         AerospikeWriteData data = AerospikeWriteData.forWrite();
         converter.write(document, data);
+
+        // Override the namespace, the aerospike template's namespace should be used in case its different from the persistent entity's namespace (default)
+        if (!data.getKey().namespace.equals(getNamespace())) {
+            Key newKey = new Key(getNamespace(), data.getKey().setName, data.getKey().userKey);
+            data.setKey(newKey);
+        }
         return data;
     }
 

--- a/src/main/java/org/springframework/data/aerospike/mapping/AerospikeMappingContext.java
+++ b/src/main/java/org/springframework/data/aerospike/mapping/AerospikeMappingContext.java
@@ -60,7 +60,7 @@ public class AerospikeMappingContext extends
 	 */
 	@Override
 	protected <T> BasicAerospikePersistentEntity<?> createPersistentEntity(TypeInformation<T> typeInformation) {
-		BasicAerospikePersistentEntity<T> entity = new BasicAerospikePersistentEntity<>(typeInformation, defaultNameSpace);
+		BasicAerospikePersistentEntity<T> entity = new BasicAerospikePersistentEntity<>(typeInformation);
 		if (context != null) {
 			entity.setEnvironment(context.getEnvironment());
 		}

--- a/src/main/java/org/springframework/data/aerospike/mapping/AerospikePersistentEntity.java
+++ b/src/main/java/org/springframework/data/aerospike/mapping/AerospikePersistentEntity.java
@@ -25,11 +25,6 @@ import org.springframework.data.mapping.PersistentEntity;
  */
 public interface AerospikePersistentEntity<T> extends PersistentEntity<T, AerospikePersistentProperty> {
 
-	/**
-	 * Returns the name of the set the {@link PersistentEntity} shall be stored in.
-	 */
-	String getNamespace();
-
 	String getSetName();
 
 	int getExpiration();

--- a/src/main/java/org/springframework/data/aerospike/mapping/BasicAerospikePersistentEntity.java
+++ b/src/main/java/org/springframework/data/aerospike/mapping/BasicAerospikePersistentEntity.java
@@ -34,25 +34,20 @@ public class BasicAerospikePersistentEntity<T> extends BasicPersistentEntity<T, 
 
 	static final int DEFAULT_EXPIRATION = 0;
 
-	private final String defaultNameSpace;
-
 	private AerospikePersistentProperty expirationProperty;
 	private Environment environment;
 	private final Lazy<String> setName;
 	private final Lazy<Integer> expiration;
 	private final Lazy<Boolean> isTouchOnRead;
 
-
 	/**
 	 * Creates a new {@link BasicAerospikePersistentEntity}
-	 * using a given {@link TypeInformation} and a default namespace.
+	 * using a given {@link TypeInformation}.
 	 *
 	 * @param information must not be {@literal null}.
-	 * @param defaultNameSpace The default namespace.
 	 */
-	public BasicAerospikePersistentEntity(TypeInformation<T> information, String defaultNameSpace) {
+	public BasicAerospikePersistentEntity(TypeInformation<T> information) {
 		super(information);
-		this.defaultNameSpace = defaultNameSpace;
 		this.setName = Lazy.of(() -> {
 			Class<T> type = getType();
 			Document annotation = type.getAnnotation(Document.class);
@@ -91,11 +86,6 @@ public class BasicAerospikePersistentEntity<T> extends BasicPersistentEntity<T, 
 
 			expirationProperty = property;
 		}
-	}
-
-	@Override
-	public String getNamespace() {
-		return defaultNameSpace;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/aerospike/repository/config/AerospikeRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/config/AerospikeRepositoryConfigurationExtension.java
@@ -43,11 +43,6 @@ public class AerospikeRepositoryConfigurationExtension extends BaseAerospikeRepo
     }
 
     @Override
-    protected String getDefaultKeyValueTemplateRef() {
-        return "aerospikeTemplate";
-    }
-
-    @Override
     public String getRepositoryFactoryBeanClassName() {
         return AerospikeRepositoryFactoryBean.class.getName();
     }

--- a/src/main/java/org/springframework/data/aerospike/repository/config/BaseAerospikeRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/config/BaseAerospikeRepositoryConfigurationExtension.java
@@ -19,10 +19,10 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.data.aerospike.repository.query.AerospikeQueryCreator;
-import org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension;
 import org.springframework.data.keyvalue.repository.config.QueryCreatorType;
 import org.springframework.data.keyvalue.repository.query.SpelQueryCreator;
 import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource;
+import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
 
 import java.util.Map;
 
@@ -30,14 +30,17 @@ import java.util.Map;
  * @author Oliver Gierke
  * @author Igor Ermolenko
  */
-public abstract class BaseAerospikeRepositoryConfigurationExtension extends KeyValueRepositoryConfigurationExtension {
+public abstract class BaseAerospikeRepositoryConfigurationExtension extends RepositoryConfigurationExtensionSupport {
+
+    protected static final String MAPPING_CONTEXT_BEAN_NAME = "aerospikeMappingContext";
+    protected static final String AEROSPIKE_TEMPLATE_BEAN_REF_ATTRIBUTE = "aerospikeTemplateRef";
 
     @Override
     public void postProcess(BeanDefinitionBuilder builder, AnnotationRepositoryConfigurationSource config) {
 
         AnnotationAttributes attributes = config.getAttributes();
 
-        builder.addPropertyReference("operations", attributes.getString(KEY_VALUE_TEMPLATE_BEAN_REF_ATTRIBUTE));
+        builder.addPropertyReference("operations", attributes.getString(AEROSPIKE_TEMPLATE_BEAN_REF_ATTRIBUTE));
         builder.addPropertyValue("queryCreator", getQueryCreatorType(config));
         builder.addPropertyReference("mappingContext", MAPPING_CONTEXT_BEAN_NAME);
     }

--- a/src/main/java/org/springframework/data/aerospike/repository/config/EnableAerospikeRepositories.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/config/EnableAerospikeRepositories.java
@@ -20,7 +20,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.aerospike.repository.support.AerospikeRepositoryFactoryBean;
 import org.springframework.data.aerospike.repository.support.SimpleAerospikeRepository;
-import org.springframework.data.keyvalue.core.KeyValueOperations;
+import org.springframework.data.aerospike.core.AerospikeOperations;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryLookupStrategy.Key;
 
@@ -101,9 +101,9 @@ public @interface EnableAerospikeRepositories {
 	Class<?> repositoryBaseClass() default SimpleAerospikeRepository.class;
 
 	/**
-	 * Configures the name of the {@link KeyValueOperations} bean to be used with the repositories detected.
+	 * Configures the name of the {@link AerospikeOperations} bean to be used with the repositories detected.
 	 */
-	String keyValueTemplateRef() default "aerospikeTemplate";
+	String aerospikeTemplateRef() default "aerospikeTemplate";
 
 	/**
 	 * Configures whether nested repository-interfaces (e.g. defined as inner classes) should be discovered by the

--- a/src/main/java/org/springframework/data/aerospike/repository/config/EnableReactiveAerospikeRepositories.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/config/EnableReactiveAerospikeRepositories.java
@@ -20,7 +20,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.aerospike.repository.support.ReactiveAerospikeRepositoryFactoryBean;
 import org.springframework.data.aerospike.repository.support.SimpleReactiveAerospikeRepository;
-import org.springframework.data.keyvalue.core.KeyValueOperations;
+import org.springframework.data.aerospike.core.ReactiveAerospikeOperations;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryLookupStrategy.Key;
 
@@ -101,9 +101,9 @@ public @interface EnableReactiveAerospikeRepositories {
 	Class<?> repositoryBaseClass() default SimpleReactiveAerospikeRepository.class;
 
 	/**
-	 * Configures the name of the {@link KeyValueOperations} bean to be used with the repositories detected.
+	 * Configures the name of the {@link ReactiveAerospikeOperations} bean to be used with the repositories detected.
 	 */
-	String keyValueTemplateRef() default "reactiveAerospikeTemplate";
+	String aerospikeTemplateRef() default "reactiveAerospikeTemplate";
 
 	/**
 	 * Configures whether nested repository-interfaces (e.g. defined as inner classes) should be discovered by the

--- a/src/main/java/org/springframework/data/aerospike/repository/config/ReactiveAerospikeRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/config/ReactiveAerospikeRepositoryConfigurationExtension.java
@@ -43,11 +43,6 @@ public class ReactiveAerospikeRepositoryConfigurationExtension extends BaseAeros
     }
 
     @Override
-    protected String getDefaultKeyValueTemplateRef() {
-        return "reactiveAerospikeTemplate";
-    }
-
-    @Override
     public String getRepositoryFactoryBeanClassName() {
         return ReactiveAerospikeRepositoryFactoryBean.class.getName();
     }

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterDeprecatedTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterDeprecatedTest.java
@@ -90,7 +90,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 		address.city = "New York";
 		address.street = "Broadway";
 
-		AerospikeWriteData dbObject = AerospikeWriteData.forWrite();
+		AerospikeWriteData dbObject = AerospikeWriteData.forWrite(key.namespace);
 		converter.write(address, dbObject);
 
 		Collection<Bin> bins = dbObject.getBins();
@@ -126,7 +126,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 
 		foo.map = Collections.singletonMap(Locale.US, "Biff");
 
-		AerospikeWriteData dbObject = AerospikeWriteData.forWrite();
+		AerospikeWriteData dbObject = AerospikeWriteData.forWrite(key.namespace);
 		converter.write(foo, dbObject);
 
 		Object object = getBinValue("map", dbObject.getBins());
@@ -138,7 +138,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 		ClassWithEnumProperty value = new ClassWithEnumProperty();
 		value.sampleEnum = SampleEnum.FIRST;
 
-		AerospikeWriteData result = AerospikeWriteData.forWrite();
+		AerospikeWriteData result = AerospikeWriteData.forWrite(key.namespace);
 		converter.write(value, result);
 
 		Object object = getBinValue("sampleEnum", result.getBins());
@@ -153,7 +153,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 		ClassWithEnumProperty value = new ClassWithEnumProperty();
 		value.enums = Arrays.asList(SampleEnum.FIRST);
 
-		AerospikeWriteData result = AerospikeWriteData.forWrite();
+		AerospikeWriteData result = AerospikeWriteData.forWrite(key.namespace);
 		converter.write(value, result);
 
 		Object object = getBinValue("enums", result.getBins());
@@ -203,7 +203,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 		person.id = "oliver-01";
 		person.firstname = "Oliver";
 
-		AerospikeWriteData dbObject = AerospikeWriteData.forWrite();
+		AerospikeWriteData dbObject = AerospikeWriteData.forWrite(key.namespace);
 		converter.write(person, dbObject);
 
 
@@ -239,7 +239,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 		person.id = "oliver-02";
 		person.addresses = Collections.emptySet();
 
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(key.namespace);
 
 		converter.write(person, forWrite);
 

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTest.java
@@ -67,7 +67,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 	public void readsCollectionOfObjectsToSetByDefault() {
 		CollectionOfObjects object = new CollectionOfObjects("my-id", list(new Person(null, set(new SampleClasses.Address(new SampleClasses.Street("Zarichna", 1), 202)))));
 
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 
 		converter.write(object, forWrite);
 
@@ -110,7 +110,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 		MappingAerospikeConverter converter =
 				getMappingAerospikeConverter(new UserToAerospikeWriteDataConverter(), new AerospikeReadDataToUserConverter());
 
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 		User user = new User(678, new Name("Nastya", "Smirnova"), null);
 		converter.write(user, forWrite);
 
@@ -130,7 +130,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 		MappingAerospikeConverter converter =
 				getMappingAerospikeConverter(new AerospikeTypeAliasAccessor(null));
 
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 		User user = new User(678L, null, null);
 		converter.write(user, forWrite);
 
@@ -148,7 +148,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 	@Test
 	public void shouldWriteExpirationValue() {
 		Person person = new Person("personId", Collections.emptySet());
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 
 		converter.write(person, forWrite);
 
@@ -189,7 +189,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 		DateTime unixTimeExpiration = DateTime.now().plusSeconds(EXPIRATION_ONE_MINUTE);
 		DocumentWithUnixTimeExpiration document = new DocumentWithUnixTimeExpiration("docId", unixTimeExpiration);
 
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 		converter.write(document, forWrite);
 
 		assertThat(forWrite.getExpiration()).isIn(EXPIRATION_ONE_MINUTE, EXPIRATION_ONE_MINUTE - 1);
@@ -200,7 +200,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 		DateTime expirationFromThePast = DateTime.now().minusSeconds(EXPIRATION_ONE_MINUTE);
 		DocumentWithUnixTimeExpiration document = new DocumentWithUnixTimeExpiration("docId", expirationFromThePast);
 
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 
 		assertThatThrownBy(() -> converter.write(document, forWrite))
 				.isInstanceOf(IllegalArgumentException.class)
@@ -210,7 +210,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 	@Test
 	public void shouldWriteExpirationFieldValue() {
 		DocumentWithExpirationAnnotation document = new DocumentWithExpirationAnnotation("docId", EXPIRATION_ONE_SECOND);
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 
 		converter.write(document, forWrite);
 
@@ -220,7 +220,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 	@Test
 	public void shouldNotSaveExpirationFieldAsBin() {
 		DocumentWithExpirationAnnotation document = new DocumentWithExpirationAnnotation("docId", EXPIRATION_ONE_SECOND);
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 
 		converter.write(document, forWrite);
 
@@ -230,7 +230,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 	@Test
 	public void shouldFailWithNullExpirationFieldValue() {
 		DocumentWithExpirationAnnotation document = new DocumentWithExpirationAnnotation("docId", null);
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 
 		assertThatThrownBy(() -> converter.write(document, forWrite))
 				.isInstanceOf(IllegalArgumentException.class)
@@ -240,7 +240,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 	@Test
 	public void shouldNotFailWithNeverExpirePolicy() {
 		DocumentWithExpirationAnnotation document = new DocumentWithExpirationAnnotation("docId", NEVER_EXPIRE);
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 
 		converter.write(document, forWrite);
 
@@ -250,7 +250,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 	@Test
 	public void shouldNotFailWithDoNotUpdateExpirePolicy() {
 		DocumentWithExpirationAnnotation document = new DocumentWithExpirationAnnotation("docId", DO_NOT_UPDATE_EXPIRATION);
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 
 		converter.write(document, forWrite);
 
@@ -283,7 +283,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 
 	@Test
 	public void shouldNotWriteVersionToBins() {
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 		converter.write(new VersionedClass("id", "data", 42L), forWrite);
 
 		assertThat(forWrite.getBins()).containsOnly(

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTypesTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTypesTest.java
@@ -428,7 +428,7 @@ public class MappingAerospikeConverterTypesTest extends BaseMappingAerospikeConv
 										Object expectedUserKey,
 										Bin... expectedBins) {
 
-		AerospikeWriteData forWrite = AerospikeWriteData.forWrite();
+		AerospikeWriteData forWrite = AerospikeWriteData.forWrite(NAMESPACE);
 
 		converter.write(object, forWrite);
 


### PR DESCRIPTION
Override the namespace, the aerospike template's namespace should be used in case its different from the persistent entity's namespace (default).

It fixes multiple namespaces configuration scenarios.