### PR TITLE
Set project version to 3.1.0 and bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The documentation for this project can be found on [javadoc.io](https://www.java
 
 |Spring Data Aerospike | Spring Boot | Aerospike Client | Aerospike Reactor Client
 | :----------- | :---- | :----------- | :-----------
-|3.0.x | 2.5.X | 5.1.x | 5.0.x
+|3.0.x, 3.1.x | 2.5.X | 5.1.x | 5.0.x
 |2.5.x | 2.5.X | 4.4.x | 4.4.x 
 |2.4.2.RELEASE | 2.3.x | 4.4.x | 4.4.x
 |2.3.5.RELEASE | 2.2.x | 4.4.x | 4.4.x
@@ -49,7 +49,7 @@ Add the Maven dependency:
 <dependency>
   <groupId>com.aerospike</groupId>
   <artifactId>spring-data-aerospike</artifactId>
-  <version>3.0.1</version>
+  <version>3.1.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.aerospike</groupId>
     <artifactId>spring-data-aerospike</artifactId>
-    <version>3.0.1</version>
+    <version>3.1.0</version>
     <name>Spring Data Aerospike</name>
     <organization>
         <name>Aerospike Inc.</name>
@@ -16,16 +16,16 @@
  	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>2.5.3</version>
+		<version>2.5.4</version>
 	</parent>
 
     <properties>
         <source.level>1.8</source.level>
-        <aerospike>5.1.6</aerospike>
+        <aerospike>5.1.7</aerospike>
         <aerospike-reactor>5.0.7</aerospike-reactor>
 
-        <springdata.commons>2.5.3</springdata.commons>
-        <springdata.keyvalue>2.5.3</springdata.keyvalue>
+        <springdata.commons>2.5.4</springdata.commons>
+        <springdata.keyvalue>2.5.4</springdata.keyvalue>
         <dist.key>DATAAERO</dist.key>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -38,9 +38,9 @@
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
 
-        <spring-boot-starter-test.version>2.5.3</spring-boot-starter-test.version>
+        <spring-boot-starter-test.version>2.5.4</spring-boot-starter-test.version>
         <spring-cloud-starter-bootstrap.version>3.0.3</spring-cloud-starter-bootstrap.version>
-        <embedded-aerospike.version>2.0.10</embedded-aerospike.version>
+        <embedded-aerospike.version>2.0.11</embedded-aerospike.version>
         <awaitility.version>4.1.0</awaitility.version>
         <blockhound.version>1.0.6.RELEASE</blockhound.version>
         <lombok.version>1.18.20</lombok.version>


### PR DESCRIPTION
1. Set project version to 3.1.0.
2. Bump dependencies:
spring-data-parent from 2.5.3 to 2.5.4.
aerospike-client from 5.1.6 to 5.1.7.
spring-data-commons from 2.5.3 to 2.5.4.
spring-data-keyvalue from 2.5.3 to 2.5.4.
spring-boot-starter-test from 2.5.3 to 2.5.4.
embedded-aerospike from 2.0.10 to 2.0.11.