### PR TITLE
Replace getPersistentEntity with getRequiredPersistentEntity

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeWriteConverter.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeWriteConverter.java
@@ -70,7 +70,7 @@ public class MappingAerospikeWriteConverter implements EntityWriter<Object, Aero
 		}
 
 		TypeInformation<?> type = ClassTypeInformation.from(source.getClass());
-		AerospikePersistentEntity<?> entity = mappingContext.getPersistentEntity(source.getClass());
+		AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(source.getClass());
 		ConvertingPropertyAccessor<?> accessor = new ConvertingPropertyAccessor<>(entity.getPropertyAccessor(source), conversionService);
 
 		AerospikePersistentProperty idProperty = entity.getIdProperty();
@@ -193,7 +193,7 @@ public class MappingAerospikeWriteConverter implements EntityWriter<Object, Aero
 		Assert.notNull(source, "Given map must not be null!");
 		Assert.notNull(type, "Given type must not be null!");
 
-		AerospikePersistentEntity<?> entity = mappingContext.getPersistentEntity(source.getClass());
+		AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(source.getClass());
 		ConvertingPropertyAccessor<?> accessor = new ConvertingPropertyAccessor<>(entity.getPropertyAccessor(source), conversionService);
 
 		return convertProperties(type, entity, accessor);

--- a/src/test/java/org/springframework/data/aerospike/mapping/AerospikeMappingContextTest.java
+++ b/src/test/java/org/springframework/data/aerospike/mapping/AerospikeMappingContextTest.java
@@ -34,7 +34,7 @@ public class AerospikeMappingContextTest {
 		context.setApplicationContext(mock(ApplicationContext.class));
 		context.setFieldNamingStrategy(null);
 		
-		AerospikePersistentEntity<?> entity = context.getPersistentEntity(Person.class);
+		AerospikePersistentEntity<?> entity = context.getRequiredPersistentEntity(Person.class);
 
 		assertThat(entity.getPersistentProperty("firstName").getField().getName()).isEqualTo("firstName");
 	}
@@ -45,7 +45,7 @@ public class AerospikeMappingContextTest {
 		context.setApplicationContext(mock(ApplicationContext.class));
 		context.setFieldNamingStrategy(null);
 		
-		AerospikePersistentEntity<?> entity = context.getPersistentEntity(Person.class);
+		AerospikePersistentEntity<?> entity = context.getRequiredPersistentEntity(Person.class);
 
 		assertThat(entity.getTypeInformation().getType().getSimpleName()).isEqualTo(Person.class.getSimpleName());
 	}

--- a/src/test/java/org/springframework/data/aerospike/mapping/AerospikePersistentEntityTest.java
+++ b/src/test/java/org/springframework/data/aerospike/mapping/AerospikePersistentEntityTest.java
@@ -34,42 +34,42 @@ public class AerospikePersistentEntityTest extends BaseBlockingIntegrationTests 
 
     @Test
     public void shouldReturnExpirationForDocumentWithExpiration() {
-        BasicAerospikePersistentEntity<?> persistentEntity = context.getPersistentEntity(DocumentWithExpiration.class);
+        BasicAerospikePersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DocumentWithExpiration.class);
 
         assertThat(persistentEntity.getExpiration()).isEqualTo(EXPIRATION_ONE_SECOND);
     }
 
     @Test
     public void shouldReturnExpirationForDocumentWithExpirationExpression() {
-        BasicAerospikePersistentEntity<?> persistentEntity = context.getPersistentEntity(DocumentWithExpirationExpression.class);
+        BasicAerospikePersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DocumentWithExpirationExpression.class);
 
         assertThat(persistentEntity.getExpiration()).isEqualTo(EXPIRATION_ONE_SECOND);
     }
 
     @Test
     public void shouldReturnExpirationForDocumentWithExpirationUnit() {
-        BasicAerospikePersistentEntity<?> persistentEntity = context.getPersistentEntity(DocumentWithExpirationUnit.class);
+        BasicAerospikePersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DocumentWithExpirationUnit.class);
 
         assertThat(persistentEntity.getExpiration()).isEqualTo((int) TimeUnit.MINUTES.toSeconds(1));
     }
 
     @Test
     public void shouldReturnZeroForDocumentWithoutExpiration() {
-        BasicAerospikePersistentEntity<?> persistentEntity = context.getPersistentEntity(DocumentWithoutExpiration.class);
+        BasicAerospikePersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DocumentWithoutExpiration.class);
 
         assertThat(persistentEntity.getExpiration()).isEqualTo(DEFAULT_EXPIRATION);
     }
 
     @Test
     public void shouldReturnZeroForDocumentWithoutAnnotation() {
-        BasicAerospikePersistentEntity<?> persistentEntity = context.getPersistentEntity(DocumentWithoutAnnotation.class);
+        BasicAerospikePersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DocumentWithoutAnnotation.class);
 
         assertThat(persistentEntity.getExpiration()).isEqualTo(DEFAULT_EXPIRATION);
     }
 
     @Test
     public void shouldFailForDocumentWithExpirationAndExpression() {
-        BasicAerospikePersistentEntity<?> persistentEntity = context.getPersistentEntity(DocumentWithExpirationAndExpression.class);
+        BasicAerospikePersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DocumentWithExpirationAndExpression.class);
 
         assertThatThrownBy(persistentEntity::getExpiration)
                 .isInstanceOf(IllegalStateException.class)
@@ -78,7 +78,7 @@ public class AerospikePersistentEntityTest extends BaseBlockingIntegrationTests 
 
     @Test
     public void shouldGetExpirationProperty() {
-        BasicAerospikePersistentEntity<?> persistentEntity = context.getPersistentEntity(DocumentWithExpirationAnnotation.class);
+        BasicAerospikePersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DocumentWithExpirationAnnotation.class);
         AerospikePersistentProperty expirationProperty = persistentEntity.getExpirationProperty();
 
         assertThat(expirationProperty).isNotNull();
@@ -88,7 +88,7 @@ public class AerospikePersistentEntityTest extends BaseBlockingIntegrationTests 
 
     @Test
     public void shouldGetExpirationPropertySpecifiedAsUnixTime() {
-        BasicAerospikePersistentEntity<?> persistentEntity = context.getPersistentEntity(DocumentWithUnixTimeExpiration.class);
+        BasicAerospikePersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DocumentWithUnixTimeExpiration.class);
         AerospikePersistentProperty expirationProperty = persistentEntity.getExpirationProperty();
 
         assertThat(expirationProperty).isNotNull();
@@ -98,7 +98,7 @@ public class AerospikePersistentEntityTest extends BaseBlockingIntegrationTests 
 
     @Test
     public void shouldFailForNonExpirationProperty() {
-        BasicAerospikePersistentEntity<?> persistentEntity = context.getPersistentEntity(DocumentWithUnixTimeExpiration.class);
+        BasicAerospikePersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DocumentWithUnixTimeExpiration.class);
         AerospikePersistentProperty expirationProperty = persistentEntity.getIdProperty();
 
         assertThatThrownBy(expirationProperty::isExpirationSpecifiedAsUnixTime)
@@ -108,7 +108,7 @@ public class AerospikePersistentEntityTest extends BaseBlockingIntegrationTests 
 
     @Test
     public void shouldResolvePlaceholdersInCollection() {
-        BasicAerospikePersistentEntity<?> persistentEntity = context.getPersistentEntity(DocumentWithExpressionInCollection.class);
+        BasicAerospikePersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DocumentWithExpressionInCollection.class);
 
         assertThat(persistentEntity.getSetName()).isEqualTo(DocumentWithExpressionInCollection.COLLECTION_PREFIX + "service1");
     }

--- a/src/test/java/org/springframework/data/aerospike/mapping/BasicAerospikePersistentEntityTest.java
+++ b/src/test/java/org/springframework/data/aerospike/mapping/BasicAerospikePersistentEntityTest.java
@@ -31,14 +31,14 @@ public class BasicAerospikePersistentEntityTest {
 
     @Test
     public void shouldReturnSimpleClassNameIfCollectionNotSpecified() {
-        BasicAerospikePersistentEntity<?> entity = context.getPersistentEntity(DocumentWithoutCollection.class);
+        BasicAerospikePersistentEntity<?> entity = context.getRequiredPersistentEntity(DocumentWithoutCollection.class);
 
         assertThat(entity.getSetName()).isEqualTo(DocumentWithoutCollection.class.getSimpleName());
     }
 
     @Test
     public void shouldFailIfEnvironmentNull() {
-        BasicAerospikePersistentEntity<?> entity = context.getPersistentEntity(DocumentWithExpressionInCollection.class);
+        BasicAerospikePersistentEntity<?> entity = context.getRequiredPersistentEntity(DocumentWithExpressionInCollection.class);
 
         assertThatThrownBy(entity::getSetName)
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/org/springframework/data/aerospike/mapping/CachingAerospikePersistentPropertyTest.java
+++ b/src/test/java/org/springframework/data/aerospike/mapping/CachingAerospikePersistentPropertyTest.java
@@ -39,35 +39,35 @@ public class CachingAerospikePersistentPropertyTest {
 
 	@Test
 	public void isTransient() {
-		AerospikePersistentEntity<?> entity = context.getPersistentEntity(Person.class);
+		AerospikePersistentEntity<?> entity = context.getRequiredPersistentEntity(Person.class);
 
 		assertThat(entity.getIdProperty().isTransient()).isFalse();
 	}
 
 	@Test
 	public void isAssociation() {
-		AerospikePersistentEntity<?> entity = context.getPersistentEntity(Person.class);
+		AerospikePersistentEntity<?> entity = context.getRequiredPersistentEntity(Person.class);
 
 		assertThat(entity.getIdProperty().isAssociation()).isFalse();
 	}
 
 	@Test
 	public void usePropertyAccess() {
-		AerospikePersistentEntity<?> entity = context.getPersistentEntity(Person.class);
+		AerospikePersistentEntity<?> entity = context.getRequiredPersistentEntity(Person.class);
 
 		assertThat(entity.getIdProperty().usePropertyAccess()).isFalse();
 	}
 
 	@Test
 	public void isIdProperty() {
-		AerospikePersistentEntity<?> entity = context.getPersistentEntity(Person.class);
+		AerospikePersistentEntity<?> entity = context.getRequiredPersistentEntity(Person.class);
 
 		assertThat(entity.getIdProperty().isIdProperty()).isTrue();
 	}
 
 	@Test
 	public void getFieldName() {
-		AerospikePersistentEntity<?> entity = context.getPersistentEntity(Person.class);
+		AerospikePersistentEntity<?> entity = context.getRequiredPersistentEntity(Person.class);
 
 		assertThat(entity.getIdProperty().getName()).isEqualTo("id");
 	}


### PR DESCRIPTION
Replace getPersistentEntity with getRequiredPersistentEntity in places where potentially NullPointerException can be thrown.