### PR TITLE
Bump java clients to version 5.1.11 to fix CLIENT-1637 bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
         <spring-boot-starter-test>2.5.6</spring-boot-starter-test>
         <maven.javadoc.plugin>3.3.0</maven.javadoc.plugin>
         <maven.gpg.plugin>1.6</maven.gpg.plugin>
-        <aerospike>5.1.9</aerospike>
-        <aerospike-reactor>5.1.8</aerospike-reactor>
+        <aerospike>5.1.11</aerospike>
+        <aerospike-reactor>5.1.11</aerospike-reactor>
         <embedded-aerospike>2.0.16</embedded-aerospike>
         <awaitility>4.1.1</awaitility>
         <blockhound>1.0.6.RELEASE</blockhound>


### PR DESCRIPTION
Java client & reactive java client version 5.1.11 fixes CLIENT-1637 issue "Continue processing scans when "partition unavailable" errors occur. "partition unavailable" is not a fatal error for partition scans and the server will continue sending back results for other partitions. Previous clients aborted the scan and put the connection back into the pool which might cause unprocessed results to be sent to a different transaction."