### PR TITLE
Prepare for version 3.4.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The documentation for this project can be found on [javadoc.io](https://www.java
 
 |Spring Data Aerospike | Spring Boot | Aerospike Client | Aerospike Reactor Client | Aerospike Server
 | :----------- | :---- | :----------- | :----------- | :-----------
+|3.4.x | 2.6.x | 5.1.x | 5.1.x | 5.2.x.x +
 |3.3.x | 2.5.x | 5.1.x | 5.1.x | 5.2.x.x +
 |3.2.x | 2.5.x | 5.1.x | 5.0.x | 5.2.x.x +
 |3.0.x, 3.1.x | 2.5.x | 5.1.x | 5.0.x
@@ -53,7 +54,7 @@ Add the Maven dependency:
 <dependency>
   <groupId>com.aerospike</groupId>
   <artifactId>spring-data-aerospike</artifactId>
-  <version>3.3.1</version>
+  <version>3.4.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.aerospike</groupId>
     <artifactId>spring-data-aerospike</artifactId>
-    <version>3.3.1</version>
+    <version>3.4.0</version>
     <name>Spring Data Aerospike</name>
     <organization>
         <name>Aerospike Inc.</name>
@@ -31,8 +31,8 @@
         <maven.gpg.plugin>1.6</maven.gpg.plugin>
         <aerospike>5.1.11</aerospike>
         <aerospike-reactor>5.1.11</aerospike-reactor>
-        <embedded-aerospike>2.0.16</embedded-aerospike>
-        <awaitility>4.1.1</awaitility>
+        <embedded-aerospike>2.1.4</embedded-aerospike>
+        <awaitility>4.2.0</awaitility>
         <blockhound>1.0.6.RELEASE</blockhound>
         <lombok>1.18.22</lombok>
     </properties>


### PR DESCRIPTION
1. Set version to 3.4.0.
2. Update README.
3. Bump dependencies:
embedded-aerospike from 2.0.16 to 2.1.4.
awaitility from 4.1.1 to 4.2.0.