### PR TITLE
Byte array converter + converters cleanup

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/convert/AerospikeConverters.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/AerospikeConverters.java
@@ -15,20 +15,15 @@
  */
 package org.springframework.data.aerospike.convert;
 
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.util.StringUtils;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-
-import org.springframework.core.convert.converter.Converter;
-
-import com.aerospike.client.Bin;
-import com.aerospike.client.Value;
-import com.aerospike.client.Value.GeoJSONValue;
-import org.springframework.data.convert.ReadingConverter;
-import org.springframework.data.convert.WritingConverter;
-import org.springframework.util.StringUtils;
 
 /**
  * Wrapper class to contain useful converters
@@ -38,134 +33,56 @@ import org.springframework.util.StringUtils;
  */
 abstract class AerospikeConverters {
 
-	private AerospikeConverters() {}
+    private AerospikeConverters() {
+    }
 
-	static Collection<Object> getConvertersToRegister() {
+    static Collection<Object> getConvertersToRegister() {
 
-		List<Object> converters = new ArrayList<>();
+        List<Object> converters = new ArrayList<>();
 
-		converters.add(BigDecimalToStringConverter.INSTANCE);
-		converters.add(StringToBigDecimalConverter.INSTANCE);
-		converters.add(LongToBooleanConverter.INSTANCE);
-		converters.add(EnumToStringConverter.INSTANCE);
+        converters.add(BigDecimalToStringConverter.INSTANCE);
+        converters.add(StringToBigDecimalConverter.INSTANCE);
+        converters.add(LongToBooleanConverter.INSTANCE);
+        converters.add(EnumToStringConverter.INSTANCE);
 
-		return converters;
-	}
+        return converters;
+    }
 
-	public enum BigDecimalToStringConverter implements Converter<BigDecimal, String> {
-		INSTANCE;
+    public enum BigDecimalToStringConverter implements Converter<BigDecimal, String> {
+        INSTANCE;
 
-		public String convert(BigDecimal source) {
-			return source.toString();
-		}
-	}
+        @Override
+        public String convert(BigDecimal source) {
+            return source.toString();
+        }
+    }
 
-	public enum StringToBigDecimalConverter implements Converter<String, BigDecimal> {
-		INSTANCE;
+    public enum StringToBigDecimalConverter implements Converter<String, BigDecimal> {
+        INSTANCE;
 
-		public BigDecimal convert(String source) {
-			return StringUtils.hasText(source) ? new BigDecimal(source) : null;
-		}
-	}
+        @Override
+        public BigDecimal convert(String source) {
+            return StringUtils.hasText(source) ? new BigDecimal(source) : null;
+        }
+    }
 
-	/**
-	 * @author Peter Milne
-	 * @author Jean Mercier
-	 */
-	@ReadingConverter
-	public enum LongToBooleanConverter implements Converter<Long, Boolean> {
-		INSTANCE;
+    @ReadingConverter
+    public enum LongToBooleanConverter implements Converter<Long, Boolean> {
+        INSTANCE;
 
-		@Override
-		public Boolean convert(Long source) {
-			return source != 0L;
-		}
+        @Override
+        public Boolean convert(Long source) {
+            return source != 0L;
+        }
+    }
 
-	}
+    @WritingConverter
+    public enum EnumToStringConverter implements Converter<Enum<?>, String> {
+        INSTANCE;
 
-	/**
-	 * @author Anastasiia Smirnova
-	 */
-	@WritingConverter
-	public enum EnumToStringConverter implements Converter<Enum<?>, String> {
-		INSTANCE;
-
-		@Override
-		public String convert(Enum<?> source) {
-			return source.name();
-		}
-
-	}
-
-	public enum LongToValueConverter implements Converter<Long, Value> {
-		INSTANCE;
-
-		@Override
-		public Value convert(Long source) {
-			return Value.get(source);
-		}
-	}
-
-	public enum BinToLongConverter implements Converter<Bin, Long> {
-		INSTANCE;
-
-		@Override
-		public Long convert(Bin source) {
-			return source.value.toLong();
-		}
-	}
-
-	public enum StringToValueConverter implements Converter<String, Value> {
-		INSTANCE;
-
-		@Override
-		public Value convert(String source) {
-			return Value.get(source);
-		}
-	}
-
-	public enum BinToStringConverter implements Converter<Bin, String> {
-		INSTANCE;
-
-		@Override
-		public String convert(Bin source) {
-			return source.value.toString();
-		}
-	}
-
-	public enum ListToValueConverter implements Converter<List<?>, Value> {
-		INSTANCE;
-
-		@Override
-		public Value convert(List<?> source) {
-			return Value.get(source);
-		}
-	}
-
-	public enum MapToValueConverter implements Converter<Map<?, ?>, Value> {
-		INSTANCE;
-
-		@Override
-		public Value convert(Map<?, ?> source) {
-			return Value.get(source);
-		}
-	}
-
-	public enum BytesToValueConverter implements Converter<Byte[], Value> {
-		INSTANCE;
-
-		@Override
-		public Value convert(Byte[] source) {
-			return Value.get(source);
-		}
-	}
-	
-	public enum StringToAerospikeGeoJSONValueConverter implements Converter<String, GeoJSONValue> {
-		INSTANCE;
-
-		@Override
-		public GeoJSONValue convert(String source) {
-			return new GeoJSONValue(source);
-		}
-	}
+        @Override
+        public String convert(Enum<?> source) {
+            return source.name();
+        }
+    }
 }

--- a/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeReadConverter.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeReadConverter.java
@@ -132,6 +132,10 @@ public class MappingAerospikeReadConverter implements EntityReader<Object, Aeros
 		if (conversions.hasCustomReadTarget(source.getClass(), targetClass)) {
 			return (T) conversionService.convert(source, targetClass);
 		} else if (propertyType.isCollectionLike()) {
+			/* Byte arrays should not be converted or waste time on unnecessary convert collection flow */
+			if (source instanceof byte[]) {
+				return (T) source;
+			}
 			return convertCollection(asCollection(source), propertyType);
 		} else if (propertyType.isMap()) {
 			return convertMap((Map<String, Object>) source, propertyType);

--- a/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeReadConverter.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeReadConverter.java
@@ -132,8 +132,12 @@ public class MappingAerospikeReadConverter implements EntityReader<Object, Aeros
 		if (conversions.hasCustomReadTarget(source.getClass(), targetClass)) {
 			return (T) conversionService.convert(source, targetClass);
 		} else if (propertyType.isCollectionLike()) {
-			/* Byte arrays should not be converted or waste time on unnecessary convert collection flow */
-			if (source instanceof byte[]) {
+			/*
+			 * Byte arrays should not be converted or waste time on unnecessary convert collection flow -
+			 * if the source type is byte[] and the target class is also byte[] ("[B").
+			 * If target is a List<Byte> then convert as a collection.
+			 */
+			if (source instanceof byte[] && targetClass.getName().equals("[B")) {
 				return (T) source;
 			}
 			return convertCollection(asCollection(source), propertyType);

--- a/src/test/java/org/springframework/data/aerospike/SampleClasses.java
+++ b/src/test/java/org/springframework/data/aerospike/SampleClasses.java
@@ -671,7 +671,16 @@ public class SampleClasses {
 		private String id;
 		@Field
 		private byte[] array;
+	}
 
+	@Data
+	@AllArgsConstructor
+	@Document
+	public static class DocumentWithByteArrayList {
+		@Id
+		private String id;
+		@Field
+		private List<Byte> array;
 	}
 
 	@Data


### PR DESCRIPTION
1. Byte arrays should not be converted or waste time on unnecessary convert collection flow (read flow only, write flow treat Byte arrays as simple fields).
2. Aerospike converters cleanup, remove unnecessary/unused converters.