### PR TITLE
Change "record" variable names to "aeroRecord" (Java 14 compatibility)

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/cache/AerospikeCache.java
+++ b/src/main/java/org/springframework/data/aerospike/cache/AerospikeCache.java
@@ -138,9 +138,9 @@ public class AerospikeCache implements Cache {
 	@Override
 	public <T> T get(Object key, Class<T> type) {
 		Key dbKey = getKey(key);
-		Record record =  client.get(null, dbKey);
-		if (record != null) {
-			AerospikeReadData data = AerospikeReadData.forRead(dbKey, record);
+		Record aeroRecord =  client.get(null, dbKey);
+		if (aeroRecord != null) {
+			AerospikeReadData data = AerospikeReadData.forRead(dbKey, aeroRecord);
 			return aerospikeConverter.read(type, data);
 		}
 		return null;

--- a/src/main/java/org/springframework/data/aerospike/convert/AerospikeReadData.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/AerospikeReadData.java
@@ -30,27 +30,27 @@ import java.util.Map;
 public class AerospikeReadData {
 
 	private final Key key;
-	private final Map<String, Object> record;
+	private final Map<String, Object> aeroRecord;
 	private final int expiration;
 	private final int version;
 
-	private AerospikeReadData(Key key, Map<String, Object> record, int expiration, int version) {
+	private AerospikeReadData(Key key, Map<String, Object> aeroRecord, int expiration, int version) {
 		this.key = key;
-		this.record = record;
+		this.aeroRecord = aeroRecord;
 		this.expiration = expiration;
 		this.version = version;
 	}
 
-	public static AerospikeReadData forRead(Key key, Record record) {
+	public static AerospikeReadData forRead(Key key, Record aeroRecord) {
 		Assert.notNull(key, "Key must not be null");
-		Assert.notNull(record, "Record must not be null");
-		Assert.notNull(record.bins, "Record bins must not be null");
+		Assert.notNull(aeroRecord, "Record must not be null");
+		Assert.notNull(aeroRecord.bins, "Record bins must not be null");
 
-		return new AerospikeReadData(key, record.bins, record.getTimeToLive(), record.generation);
+		return new AerospikeReadData(key, aeroRecord.bins, aeroRecord.getTimeToLive(), aeroRecord.generation);
 	}
 
-	public Map<String, Object> getRecord() {
-		return record;
+	public Map<String, Object> getAeroRecord() {
+		return aeroRecord;
 	}
 
 	public Key getKey() {
@@ -58,7 +58,7 @@ public class AerospikeReadData {
 	}
 
 	public Object getValue(String key) {
-		return record.get(key);
+		return aeroRecord.get(key);
 	}
 
 	public int getExpiration() {

--- a/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeReadConverter.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeReadConverter.java
@@ -76,8 +76,8 @@ public class MappingAerospikeReadConverter implements EntityReader<Object, Aeros
 			return null;
 		}
 
-		Map<String, Object> record = data.getRecord();
-		TypeInformation<? extends R> typeToUse = typeMapper.readType(record, ClassTypeInformation.from(targetClass));
+		Map<String, Object> aeroRecord = data.getAeroRecord();
+		TypeInformation<? extends R> typeToUse = typeMapper.readType(aeroRecord, ClassTypeInformation.from(targetClass));
 		Class<? extends R> rawType = typeToUse.getType();
 		if (conversions.hasCustomReadTarget(AerospikeReadData.class, rawType)) {
 			return conversionService.convert(data, rawType);
@@ -248,7 +248,7 @@ public class MappingAerospikeReadConverter implements EntityReader<Object, Aeros
 		private final Map<String, Object> source;
 
 		public RecordReadingPropertyValueProvider(AerospikeReadData readData) {
-			this(readData.getKey(), readData.getExpiration(), readData.getVersion(), readData.getRecord());
+			this(readData.getKey(), readData.getExpiration(), readData.getVersion(), readData.getAeroRecord());
 		}
 
 		public RecordReadingPropertyValueProvider(Map<String, Object> source) {

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeKeyValueAdapter.java
@@ -81,11 +81,11 @@ public class AerospikeKeyValueAdapter extends AbstractKeyValueAdapter {
 	@Override
 	public Object get(Object id, String keyspace) {
 		Key key = makeKey(keyspace, id.toString());
-		Record record = client.get(null, key);
-		if(record == null){
+		Record aeroRecord = client.get(null, key);
+		if(aeroRecord == null){
 			return null;
 		}
-		AerospikeReadData data = AerospikeReadData.forRead(key, record);
+		AerospikeReadData data = AerospikeReadData.forRead(key, aeroRecord);
 		return converter.read(Object.class,  data);
 	}
 

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -255,8 +255,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 			AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(entityClass);
 			Key key = getKey(id, entity);
 
-			Record record = this.client.operate(null, key, Operation.getHeader());
-			return record != null;
+			Record aeroRecord = this.client.operate(null, key, Operation.getHeader());
+			return aeroRecord != null;
 		} catch (AerospikeException e) {
 			throw translateError(e);
 		}
@@ -278,15 +278,15 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 			AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(entityClass);
 			Key key = getKey(id, entity);
 
-			Record record;
+			Record aeroRecord;
 			if (entity.isTouchOnRead()) {
 				Assert.state(!entity.hasExpirationProperty(), "Touch on read is not supported for expiration property");
-				record = getAndTouch(key, entity.getExpiration());
+				aeroRecord = getAndTouch(key, entity.getExpiration());
 			} else {
-				record = this.client.get(null, key);
+				aeroRecord = this.client.get(null, key);
 			}
 
-			return mapToEntity(key, entityClass, record);
+			return mapToEntity(key, entityClass, aeroRecord);
 		}
 		catch (AerospikeException e) {
 			throw translateError(e);
@@ -325,11 +325,11 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 					.map(id -> getKey(id, entity))
 					.toArray(Key[]::new);
 
-			Record[] records = client.get(null, keys);
+			Record[] aeroRecords = client.get(null, keys);
 
 			return IntStream.range(0, keys.length)
-					.filter(index -> records[index] != null)
-					.mapToObj(index -> mapToEntity(keys[index], entityClass, records[index]))
+					.filter(index -> aeroRecords[index] != null)
+					.mapToObj(index -> mapToEntity(keys[index], entityClass, aeroRecords[index]))
 					.collect(Collectors.toList());
 		} catch (AerospikeException e) {
 			throw translateError(e);
@@ -349,9 +349,9 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 
 	private GroupedEntities findEntitiesByIdsInternal(GroupedKeys groupedKeys) {
 		EntitiesKeys entitiesKeys = EntitiesKeys.of(toEntitiesKeyMap(groupedKeys));
-		Record[] records = client.get(null, entitiesKeys.getKeys());
+		Record[] aeroRecords = client.get(null, entitiesKeys.getKeys());
 
-		return toGroupedEntities(entitiesKeys, records);
+		return toGroupedEntities(entitiesKeys, aeroRecords);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -463,11 +463,11 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 
 		try {
 			AerospikeWriteData data = writeData(document);
-			Record record = this.client.operate(null, data.getKey(),
+			Record aeroRecord = this.client.operate(null, data.getKey(),
 					Operation.prepend(new Bin(fieldName, value)),
 					Operation.get(fieldName));
 
-			return mapToEntity(data.getKey(), getEntityClass(document), record);
+			return mapToEntity(data.getKey(), getEntityClass(document), aeroRecord);
 		} catch (AerospikeException e) {
 			throw translateError(e);
 		}
@@ -481,9 +481,9 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 		try {
 			AerospikeWriteData data = writeData(document);
 			Operation[] ops = operations(values, Operation.Type.PREPEND, Operation.get());
-			Record record = this.client.operate(null, data.getKey(), ops);
+			Record aeroRecord = this.client.operate(null, data.getKey(), ops);
 
-			return mapToEntity(data.getKey(), getEntityClass(document), record);
+			return mapToEntity(data.getKey(), getEntityClass(document), aeroRecord);
 		}
 		catch (AerospikeException e) {
 			throw translateError(e);
@@ -498,9 +498,9 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 		try {
 			AerospikeWriteData data = writeData(document);
 			Operation[] ops = operations(values, Operation.Type.APPEND, Operation.get());
-			Record record = this.client.operate(null, data.getKey(), ops);
+			Record aeroRecord = this.client.operate(null, data.getKey(), ops);
 
-			return mapToEntity(data.getKey(), getEntityClass(document), record);
+			return mapToEntity(data.getKey(), getEntityClass(document), aeroRecord);
 		}
 		catch (AerospikeException e) {
 			throw translateError(e);
@@ -514,11 +514,11 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 		try {
 
 			AerospikeWriteData data = writeData(document);
-			Record record = this.client.operate(null, data.getKey(),
+			Record aeroRecord = this.client.operate(null, data.getKey(),
 					Operation.append(new Bin(binName, value)),
 					Operation.get(binName));
 
-			return mapToEntity(data.getKey(), getEntityClass(document), record);
+			return mapToEntity(data.getKey(), getEntityClass(document), aeroRecord);
 		} catch (AerospikeException e) {
 			throw translateError(e);
 		}
@@ -537,9 +537,9 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 					.expiration(data.getExpiration())
 					.build();
 
-			Record record = this.client.operate(writePolicy, data.getKey(), ops);
+			Record aeroRecord = this.client.operate(writePolicy, data.getKey(), ops);
 
-			return mapToEntity(data.getKey(), getEntityClass(document), record);
+			return mapToEntity(data.getKey(), getEntityClass(document), aeroRecord);
 		} catch (AerospikeException e) {
 			throw translateError(e);
 		}
@@ -557,10 +557,10 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 					.expiration(data.getExpiration())
 					.build();
 
-			Record record = this.client.operate(writePolicy, data.getKey(),
+			Record aeroRecord = this.client.operate(writePolicy, data.getKey(),
 					Operation.add(new Bin(binName, value)), Operation.get());
 
-			return mapToEntity(data.getKey(), getEntityClass(document), record);
+			return mapToEntity(data.getKey(), getEntityClass(document), aeroRecord);
 		} catch (AerospikeException e) {
 			throw translateError(e);
 		}
@@ -576,8 +576,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 
 	private <T> void doPersistWithVersionAndHandleCasError(T document, AerospikeWriteData data, WritePolicy policy) {
 		try {
-			Record newRecord = putAndGetHeader(data, policy);
-			updateVersion(document, newRecord);
+			Record newAeroRecord = putAndGetHeader(data, policy);
+			updateVersion(document, newAeroRecord);
 		} catch (AerospikeException e) {
 			throw translateCasError(e);
 		}
@@ -585,8 +585,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 
 	private <T> void doPersistWithVersionAndHandleError(T document, AerospikeWriteData data, WritePolicy policy) {
 		try {
-			Record newRecord = putAndGetHeader(data, policy);
-			updateVersion(document, newRecord);
+			Record newAeroRecord = putAndGetHeader(data, policy);
+			updateVersion(document, newAeroRecord);
 		} catch (AerospikeException e) {
 			throw translateError(e);
 		}

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -125,11 +125,11 @@ abstract class BaseAerospikeTemplate {
         return (Class<T>) entity.getClass();
     }
 
-    <T> T mapToEntity(Key key, Class<T> type, Record record) {
-        if (record == null) {
+    <T> T mapToEntity(Key key, Class<T> type, Record aeroRecord) {
+        if (aeroRecord == null) {
             return null;
         }
-        AerospikeReadData data = AerospikeReadData.forRead(key, record);
+        AerospikeReadData data = AerospikeReadData.forRead(key, aeroRecord);
         return converter.read(type, data);
     }
 
@@ -151,11 +151,11 @@ abstract class BaseAerospikeTemplate {
         return new ConvertingPropertyAccessor<>(accessor, converter.getConversionService());
     }
 
-    <T> T updateVersion(T document, Record newRecord) {
+    <T> T updateVersion(T document, Record newAeroRecord) {
         AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(document.getClass());
         ConvertingPropertyAccessor<T> propertyAccessor = getPropertyAccessor(entity, document);
         AerospikePersistentProperty versionProperty = entity.getRequiredVersionProperty();
-        propertyAccessor.setProperty(versionProperty, newRecord.generation);
+        propertyAccessor.setProperty(versionProperty, newAeroRecord.generation);
         return document;
     }
 

--- a/src/test/java/org/springframework/data/aerospike/convert/BaseMappingAerospikeConverterTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/BaseMappingAerospikeConverterTest.java
@@ -51,13 +51,13 @@ public abstract class BaseMappingAerospikeConverterTest {
 		return applicationContext;
 	}
 
-	protected static Record record(Collection<Bin> bins) {
+	protected static Record aeroRecord(Collection<Bin> bins) {
 		Map<String, Object> collect = bins.stream()
 				.collect(Collectors.toMap(bin -> bin.name, bin -> bin.value.getObject()));
-		return record(collect);
+		return aeroRecord(collect);
 	}
 
-	protected static Record record(Map<String, Object> bins) {
+	protected static Record aeroRecord(Map<String, Object> bins) {
 		return new Record(bins, 0, 0);
 	}
 }

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterDeprecatedTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterDeprecatedTest.java
@@ -112,7 +112,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 			}
 		};
 
-		AerospikeReadData dbObject = AerospikeReadData.forRead(key, record(bins));
+		AerospikeReadData dbObject = AerospikeReadData.forRead(key, aeroRecord(bins));
 
 		Address convertedAddress = converter.read(Address.class, dbObject);
 
@@ -171,7 +171,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 			}
 		};
 
-		AerospikeReadData dbObject = AerospikeReadData.forRead(key, record(bins));
+		AerospikeReadData dbObject = AerospikeReadData.forRead(key, aeroRecord(bins));
 
 		ClassWithEnumProperty result = converter.read(ClassWithEnumProperty.class, dbObject);
 
@@ -188,7 +188,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 			}
 		};
 
-		AerospikeReadData dbObject = AerospikeReadData.forRead(key, record(bins));
+		AerospikeReadData dbObject = AerospikeReadData.forRead(key, aeroRecord(bins));
 
 		ClassWithEnumProperty result = converter.read(ClassWithEnumProperty.class, dbObject);
 
@@ -226,7 +226,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 			}
 		};
 
-		AerospikeReadData dbObject = AerospikeReadData.forRead(key, record(bins));
+		AerospikeReadData dbObject = AerospikeReadData.forRead(key, aeroRecord(bins));
 
 		Person result = converter.read(Person.class, dbObject);
 
@@ -244,7 +244,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 		converter.write(person, forWrite);
 
 		Map<String, Object> bins = listToMap(forWrite.getBins());
-		AerospikeReadData forRead = AerospikeReadData.forRead(key, record(bins));
+		AerospikeReadData forRead = AerospikeReadData.forRead(key, aeroRecord(bins));
 		Person result = converter.read(Person.class, forRead);
 
 		assertThat(result.addresses).isEmpty();
@@ -265,7 +265,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 				put("map", map);
 			}
 		};
-		AerospikeReadData dbObject = AerospikeReadData.forRead(key, record(bins));
+		AerospikeReadData dbObject = AerospikeReadData.forRead(key, aeroRecord(bins));
 
 		ClassWithSortedMap result = converter.read(ClassWithSortedMap.class, dbObject);
 
@@ -297,7 +297,7 @@ public class MappingAerospikeConverterDeprecatedTest {
 				.findFirst().orElse(null);
 	}
 
-	private Record record(Map<String, Object> bins) {
+	private Record aeroRecord(Map<String, Object> bins) {
 		return new Record(bins, 0, 0);
 	}
 

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTest.java
@@ -71,7 +71,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 
 		converter.write(object, forWrite);
 
-		AerospikeReadData forRead = AerospikeReadData.forRead(forWrite.getKey(), record(forWrite.getBins()));
+		AerospikeReadData forRead = AerospikeReadData.forRead(forWrite.getKey(), aeroRecord(forWrite.getBins()));
 		CollectionOfObjects actual = converter.read(CollectionOfObjects.class, forRead);
 
 		assertThat(actual).isEqualTo(
@@ -84,7 +84,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 				"listOfObjects", ImmutableList.of("firstItem", of("keyInList", "valueInList")),
 				"mapWithObjectValue", of("map", of("key", "value"))
 		));
-		AerospikeReadData forRead = AerospikeReadData.forRead(new Key(NAMESPACE, SIMPLESET, 10L), record(bins));
+		AerospikeReadData forRead = AerospikeReadData.forRead(new Key(NAMESPACE, SIMPLESET, 10L), aeroRecord(bins));
 
 		CustomTypeWithCustomTypeImmutable actual = converter.read(CustomTypeWithCustomTypeImmutable.class, forRead);
 
@@ -99,7 +99,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 				"@_class", Person.class.getName(),
 				"addresses", list()
 		);
-		AerospikeReadData dbObject = AerospikeReadData.forRead(new Key(NAMESPACE, "Person", "kate-01"), record(bins));
+		AerospikeReadData dbObject = AerospikeReadData.forRead(new Key(NAMESPACE, "Person", "kate-01"), aeroRecord(bins));
 
 		Contact result = converter.read(Contact.class, dbObject);
 		assertThat(result).isInstanceOf(Person.class);
@@ -120,7 +120,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 		);
 
 		Map<String, Object> bins = of("fs", "Nastya", "ls", "Smirnova");
-		User read = converter.read(User.class, AerospikeReadData.forRead(forWrite.getKey(), record(bins)));
+		User read = converter.read(User.class, AerospikeReadData.forRead(forWrite.getKey(), aeroRecord(bins)));
 
 		assertThat(read).isEqualTo(user);
 	}
@@ -159,7 +159,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 		assertThat(forWrite.getBins().stream().filter(x -> !x.name.equals("@_class"))).containsOnly(new Bin("entityMap", entityMapExpectedAfterConversion));
 
 		Map<String, Object> bins = of("entityMap", entityMapExpectedAfterConversion);
-		SampleClasses.DocumentExample read = converter.read(SampleClasses.DocumentExample.class, AerospikeReadData.forRead(forWrite.getKey(), record(bins)));
+		SampleClasses.DocumentExample read = converter.read(SampleClasses.DocumentExample.class, AerospikeReadData.forRead(forWrite.getKey(), aeroRecord(bins)));
 
 		assertThat(read).isEqualTo(documentExample);
 	}
@@ -327,7 +327,7 @@ public class MappingAerospikeConverterTest extends BaseMappingAerospikeConverter
 	public void shouldReadObjectWithByteArrayFieldWithOneValueInData() {
 		Map<String, Object> bins = new HashMap<>();
 		bins.put("array", 1);
-		AerospikeReadData forRead = AerospikeReadData.forRead(new Key(NAMESPACE, "DocumentWithByteArray", "user-id"), record(bins));
+		AerospikeReadData forRead = AerospikeReadData.forRead(new Key(NAMESPACE, "DocumentWithByteArray", "user-id"), aeroRecord(bins));
 
 		DocumentWithByteArray actual = converter.read(DocumentWithByteArray.class, forRead);
 

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTypesTest.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTypesTest.java
@@ -409,7 +409,7 @@ public class MappingAerospikeConverterTypesTest extends BaseMappingAerospikeConv
 				new Bin("array", Arrays.asList((byte) 1, (byte) 2, (byte) 3))
 		);
 
-		AerospikeReadData forRead = AerospikeReadData.forRead(forWrite.getKey(), record(forWrite.getBins()));
+		AerospikeReadData forRead = AerospikeReadData.forRead(forWrite.getKey(), aeroRecord(forWrite.getBins()));
 		DocumentWithByteArray actual = converter.read(DocumentWithByteArray.class, forRead);
 
 		assertThat(actual).isEqualTo(new DocumentWithByteArray("user-id", new byte[]{1, 2, 3}));
@@ -428,7 +428,7 @@ public class MappingAerospikeConverterTypesTest extends BaseMappingAerospikeConv
 				new Bin("array", new byte[]{1, 2, 3})
 		);
 
-		AerospikeReadData forRead = AerospikeReadData.forRead(forWrite.getKey(), record(forWrite.getBins()));
+		AerospikeReadData forRead = AerospikeReadData.forRead(forWrite.getKey(), aeroRecord(forWrite.getBins()));
 		DocumentWithByteArrayList actual = converter.read(DocumentWithByteArrayList.class, forRead);
 
 		assertThat(actual).isEqualTo(new DocumentWithByteArrayList("user-id", Arrays.asList((byte) 1, (byte) 2, (byte) 3)));
@@ -446,7 +446,7 @@ public class MappingAerospikeConverterTypesTest extends BaseMappingAerospikeConv
 		KeyAssert.assertThat(forWrite.getKey()).consistsOf(NAMESPACE, expectedSet, expectedUserKey);
 		assertThat(forWrite.getBins()).containsOnly(expectedBins);
 
-		AerospikeReadData forRead = AerospikeReadData.forRead(forWrite.getKey(), record(forWrite.getBins()));
+		AerospikeReadData forRead = AerospikeReadData.forRead(forWrite.getKey(), aeroRecord(forWrite.getBins()));
 
 		T actual = (T) converter.read(object.getClass(), forRead);
 

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
@@ -47,9 +47,9 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
 
         template.save(new VersionedClass(id, "foo2", 2L));
 
-        Record record2 = client.get(new Policy(), key);
-        assertThat(record2.bins.get("notPresent")).isNull();
-        assertThat(record2.bins.get("field")).isEqualTo("foo2");
+        Record aeroRecord = client.get(new Policy(), key);
+        assertThat(aeroRecord.bins.get("notPresent")).isNull();
+        assertThat(aeroRecord.bins.get("field")).isEqualTo("foo2");
     }
 
     @Test


### PR DESCRIPTION
Change "record" variable names to "aeroRecord" to avoid conflict with Java 14 reserved "record" key word.