### PR TITLE
Fix missing id in nested POJOs

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeWriteConverter.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeWriteConverter.java
@@ -89,7 +89,7 @@ public class MappingAerospikeWriteConverter implements EntityWriter<Object, Aero
 
 		data.setExpiration(getExpiration(entity, accessor));
 
-		Map<String, Object> convertedProperties = convertProperties(type, entity, accessor);
+		Map<String, Object> convertedProperties = convertProperties(type, entity, accessor, false);
 
 		if (data.getRequestedBins().isEmpty()) {
 			convertedProperties.forEach(data::addBin);
@@ -110,17 +110,22 @@ public class MappingAerospikeWriteConverter implements EntityWriter<Object, Aero
 	}
 
 	private Map<String, Object> convertProperties(TypeInformation<?> type, AerospikePersistentEntity<?> entity,
-												  ConvertingPropertyAccessor<?> accessor) {
+												  ConvertingPropertyAccessor<?> accessor, boolean isCustomType) {
 		Map<String, Object> target = new HashMap<>();
 		typeMapper.writeType(type, target);
 		entity.doWithProperties((PropertyHandler<AerospikePersistentProperty>) property -> {
 
 			Object value = accessor.getProperty(property);
-			if (isNotWritable(property)) {
+			/*
+				For custom types bins - for example a nested POJO (Person has a friend field which is also a person),
+				We want to keep non-writable types (@Id, @Expiration and @version) as they are.
+				This is not relevant for records, only for custom type bins.
+			 */
+			if (isNotWritable(property) && !isCustomType) {
 				return;
 			}
 			Object valueToWrite = getValueToWrite(value, property.getTypeInformation());
-			if(valueToWrite != null) {
+			if (valueToWrite != null) {
 				target.put(property.getFieldName(), valueToWrite);
 			}
 		});
@@ -205,7 +210,7 @@ public class MappingAerospikeWriteConverter implements EntityWriter<Object, Aero
 		AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(source.getClass());
 		ConvertingPropertyAccessor<?> accessor = new ConvertingPropertyAccessor<>(entity.getPropertyAccessor(source), conversionService);
 
-		return convertProperties(type, entity, accessor);
+		return convertProperties(type, entity, accessor, true);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/org/springframework/data/aerospike/repository/PersonRepositoryQueryTests.java
+++ b/src/test/java/org/springframework/data/aerospike/repository/PersonRepositoryQueryTests.java
@@ -145,28 +145,18 @@ public class PersonRepositoryQueryTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void findPersonsByFriendAge() {
-        carter.setFriend(dave);
-        repository.save(carter);
-        dave.setFriend(oliver);
-        repository.save(dave);
         oliver.setFriend(alicia);
         repository.save(oliver);
+        dave.setFriend(oliver);
+        repository.save(dave);
+        carter.setFriend(dave);
+        repository.save(carter);
 
-        try {
-            List<Person> result = repository.findByFriendAge(42);
+        List<Person> result = repository.findByFriendAge(42);
 
-            assertThat(result)
-                    .hasSize(1)
-                    .extracting(Person::getFirstName)
-                    .containsExactly(carter.getFirstName()); // not comparing Persons because friend id comes as null
-        } finally {
-            carter.setFriend(null); // temporarily until bringing friend id is fixed
-            repository.save(carter);
-            dave.setFriend(null);
-            repository.save(dave);
-            oliver.setFriend(null);
-            repository.save(oliver);
-        }
+        assertThat(result)
+                .hasSize(1)
+                .containsExactly(carter);
     }
 
     @Test
@@ -187,65 +177,41 @@ public class PersonRepositoryQueryTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void findPersonsByFriendAgeGreaterThan() {
-        carter.setFriend(dave);
-        repository.save(carter);
         dave.setFriend(oliver);
         repository.save(dave);
-        alicia.setFriend(boyd);
-        repository.save(alicia);
+        carter.setFriend(dave);
+        repository.save(carter);
         leroi.setFriend(carter);
         repository.save(leroi);
+        alicia.setFriend(boyd);
+        repository.save(alicia);
 
         assertThat(alicia.getFriend().getAge()).isGreaterThan(42);
         assertThat(leroi.getFriend().getAge()).isGreaterThan(42);
 
         List<Person> result = repository.findByFriendAgeGreaterThan(42);
 
-        try {
-            assertThat(result)
-                .hasSize(2)
-                .extracting(Person::getFirstName)
-                .containsExactlyInAnyOrder(alicia.getFirstName(), leroi.getFirstName()); // not comparing Persons because friend id comes as null
-        } finally {
-            carter.setFriend(null); // temporarily until bringing friend id is fixed
-            repository.save(carter);
-            dave.setFriend(null);
-            repository.save(dave);
-            alicia.setFriend(null);
-            repository.save(alicia);
-            leroi.setFriend(null);
-            repository.save(leroi);
-        }
+        assertThat(result)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(alicia, leroi);
     }
 
     @Test
     public void findPersonsByFriendAgeGreaterOrEqual () {
-        carter.setFriend(dave);
-        repository.save(carter);
         dave.setFriend(oliver);
         repository.save(dave);
-        alicia.setFriend(boyd);
-        repository.save(alicia);
+        carter.setFriend(dave);
+        repository.save(carter);
         leroi.setFriend(carter);
         repository.save(leroi);
+        alicia.setFriend(boyd);
+        repository.save(alicia);
 
-        try {
-            List<Person> result = repository.findByFriendAgeGreaterThanEqual(42);
+        List<Person> result = repository.findByFriendAgeGreaterThanEqual(42);
 
-            assertThat(result)
-                    .hasSize(3)
-                    .extracting(Person::getFirstName)
-                    .containsExactlyInAnyOrder(carter.getFirstName(), alicia.getFirstName(), leroi.getFirstName()); // not comparing Persons because friend id comes as null
-        } finally {
-            carter.setFriend(null); // temporarily until bringing friend id is fixed
-            repository.save(carter);
-            dave.setFriend(null);
-            repository.save(dave);
-            alicia.setFriend(null);
-            repository.save(alicia);
-            leroi.setFriend(null);
-            repository.save(leroi);
-        }
+        assertThat(result)
+                .hasSize(3)
+                .containsExactlyInAnyOrder(carter, alicia, leroi);
     }
 
     @Test
@@ -452,24 +418,16 @@ public class PersonRepositoryQueryTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void findsPersonsByFriendFirstnameStartsWith() {
-        carter.setFriend(dave);
-        repository.save(carter);
         dave.setFriend(oliver);
         repository.save(dave);
+        carter.setFriend(dave);
+        repository.save(carter);
 
-        try {
-            List<Person> result = repository.findByFriendFirstNameStartsWith("D");
+        List<Person> result = repository.findByFriendFirstNameStartsWith("D");
 
-            assertThat(result)
-                    .hasSize(1)
-                    .extracting(Person::getFirstName)
-                    .containsExactly(carter.getFirstName()); // not comparing Persons because friend id comes as null
-        } finally {
-            carter.setFriend(null);   // temporarily until bringing friend id is fixed
-            repository.save(carter);
-            dave.setFriend(null);
-            repository.save(dave);
-        }
+        assertThat(result)
+                .hasSize(1)
+                .containsExactly(carter);
     }
 
     @Test
@@ -504,30 +462,21 @@ public class PersonRepositoryQueryTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void findPersonsByFriendsInAgeRangeCorrectly() {
-        carter.setFriend(dave);
-        repository.save(carter);
-        dave.setFriend(oliver);
-        repository.save(dave);
         oliver.setFriend(alicia);
         repository.save(oliver);
+        dave.setFriend(oliver);
+        repository.save(dave);
+        carter.setFriend(dave);
+        repository.save(carter);
 
-        try {
-            List<Person> result = repository.findByFriendAgeBetween(40, 45);
+        List<Person> result = repository.findByFriendAgeBetween(40, 45);
 
-            assertThat(result)
-                    .hasSize(1)
-                    .extracting(Person::getFirstName)
-                    .containsExactly(carter.getFirstName()); // not comparing Persons because friend id comes as null
-        } finally {
-            carter.setFriend(null);  // temporarily until bringing friend id is fixed
-            repository.save(carter);
-            dave.setFriend(null);
-            repository.save(dave);
-            oliver.setFriend(null);
-            repository.save(oliver);
-        }
+        assertThat(result)
+                .hasSize(1)
+                .containsExactly(carter);
     }
 
+    // TODO: there is a ticket for that, FMWK-53
     /*
 	@Ignore("Searching by association not Supported Yet!" )
     @Test


### PR DESCRIPTION
For custom types bins - for example a nested POJO (Person has a friend field which is also a person),

We want to keep non-writable types (@Id, @Expiration and @version) as they are. This is not relevant for records, only for custom type bins.