### PR TITLE
Don't check for the existence of a key in a "get and touch" operation

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -369,7 +369,7 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
                 .expiration(expiration)
                 .build();
 
-        if (this.client.exists(null, key)) {
+        try {
             if (binNames == null || binNames.length == 0) {
                 return this.client.operate(writePolicy, key, Operation.touch(), Operation.get());
             } else {
@@ -381,8 +381,12 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
                 }
                 return this.client.operate(writePolicy, key, operations);
             }
+        } catch (AerospikeException aerospikeException) {
+            if (aerospikeException.getResultCode() == ResultCode.KEY_NOT_FOUND_ERROR) {
+                return null;
+            }
+            throw aerospikeException;
         }
-        return null;
     }
 
     private String[] getBinNamesFromTargetClass(Class<?> targetClass) {


### PR DESCRIPTION
We discovered during flame graph analysis, that the repository 'findById' operation takes more time than the 'save' one.

We see that there is an 'exists' operation because we have @Document(touchOnRead = true) on the Entity class.

The proposal is to remove the 'aerospikeClient.exists', and just check that AerospikeException with ResultCode == KEY_NOT_FOUND_ERROR  is raised on 'aerospikeClient.operate'.