### PR TITLE
Use IAerospikeReactorClient where possible

### DIFF
--- a/src/main/asciidoc/reference/aerospike-reactive-repositories.adoc
+++ b/src/main/asciidoc/reference/aerospike-reactive-repositories.adoc
@@ -150,12 +150,12 @@ public class ReactiveRepositoryExample {
     @Autowired
     ReactiveAerospikeOperations aerospikeOperations;
     @Autowired
-    AerospikeReactorClient client;
+    IAerospikeReactorClient client;
 
     public RepositoryExample(ApplicationContext ctx) {
         aerospikeOperations = ctx.getBean(ReactiveAerospikeTemplate.class);
         repository = (ReactivePersonRepository) ctx.getBean("reactivePersonRepository");
-        client = ctx.getBean(AerospikeReactorClient.class);
+        client = ctx.getBean(IAerospikeReactorClient.class);
     }
 
     protected void setUp() {

--- a/src/main/java/org/springframework/data/aerospike/config/AbstractReactiveAerospikeDataConfiguration.java
+++ b/src/main/java/org/springframework/data/aerospike/config/AbstractReactiveAerospikeDataConfiguration.java
@@ -19,6 +19,7 @@ import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.async.EventLoops;
 import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.client.reactor.AerospikeReactorClient;
+import com.aerospike.client.reactor.IAerospikeReactorClient;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -49,14 +50,14 @@ public abstract class AbstractReactiveAerospikeDataConfiguration extends Aerospi
     public ReactiveAerospikeTemplate reactiveAerospikeTemplate(MappingAerospikeConverter mappingAerospikeConverter,
                                                                AerospikeMappingContext aerospikeMappingContext,
                                                                AerospikeExceptionTranslator aerospikeExceptionTranslator,
-                                                               AerospikeReactorClient aerospikeReactorClient,
+                                                               IAerospikeReactorClient aerospikeReactorClient,
                                                                ReactorQueryEngine reactorQueryEngine, ReactorIndexRefresher reactorIndexRefresher) {
         return new ReactiveAerospikeTemplate(aerospikeReactorClient, nameSpace(), mappingAerospikeConverter, aerospikeMappingContext,
                 aerospikeExceptionTranslator, reactorQueryEngine, reactorIndexRefresher);
     }
 
     @Bean(name = "reactiveAerospikeQueryEngine")
-    public ReactorQueryEngine reactorQueryEngine(AerospikeReactorClient aerospikeReactorClient,
+    public ReactorQueryEngine reactorQueryEngine(IAerospikeReactorClient aerospikeReactorClient,
                                                  StatementBuilder statementBuilder,
                                                  FilterExpressionsBuilder filterExpressionsBuilder) {
         ReactorQueryEngine queryEngine = new ReactorQueryEngine(aerospikeReactorClient, statementBuilder, filterExpressionsBuilder, aerospikeReactorClient.getQueryPolicyDefault());
@@ -65,7 +66,7 @@ public abstract class AbstractReactiveAerospikeDataConfiguration extends Aerospi
     }
 
     @Bean(name = "reactiveAerospikeIndexRefresher")
-    public ReactorIndexRefresher reactorIndexRefresher(AerospikeReactorClient aerospikeReactorClient, IndexesCacheUpdater indexesCacheUpdater) {
+    public ReactorIndexRefresher reactorIndexRefresher(IAerospikeReactorClient aerospikeReactorClient, IndexesCacheUpdater indexesCacheUpdater) {
         ReactorIndexRefresher refresher = new ReactorIndexRefresher(aerospikeReactorClient, aerospikeReactorClient.getInfoPolicyDefault(),
                 new InternalIndexOperations(new IndexInfoParser()), indexesCacheUpdater);
         refresher.refreshIndexes().block();
@@ -73,7 +74,7 @@ public abstract class AbstractReactiveAerospikeDataConfiguration extends Aerospi
     }
 
     @Bean(name = "aerospikeReactorClient")
-    public AerospikeReactorClient aerospikeReactorClient(IAerospikeClient aerospikeClient) {
+    public IAerospikeReactorClient aerospikeReactorClient(IAerospikeClient aerospikeClient) {
         return new AerospikeReactorClient(aerospikeClient);
     }
 

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
@@ -25,7 +25,6 @@ import com.aerospike.client.query.Filter;
 import com.aerospike.client.query.IndexCollectionType;
 import com.aerospike.client.query.IndexType;
 import com.aerospike.client.query.KeyRecord;
-import com.aerospike.client.reactor.AerospikeReactorClient;
 import com.aerospike.client.reactor.IAerospikeReactorClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.aerospike.convert.AerospikeWriteData;
@@ -63,11 +62,11 @@ import static org.springframework.data.aerospike.core.OperationUtils.operations;
 @Slf4j
 public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements ReactiveAerospikeOperations {
 
-    private final AerospikeReactorClient reactorClient;
+    private final IAerospikeReactorClient reactorClient;
     private final ReactorQueryEngine queryEngine;
     private final ReactorIndexRefresher reactorIndexRefresher;
 
-    public ReactiveAerospikeTemplate(AerospikeReactorClient reactorClient,
+    public ReactiveAerospikeTemplate(IAerospikeReactorClient reactorClient,
                                      String namespace,
                                      MappingAerospikeConverter converter,
                                      AerospikeMappingContext mappingContext,

--- a/src/test/java/org/springframework/data/aerospike/BaseReactiveIntegrationTests.java
+++ b/src/test/java/org/springframework/data/aerospike/BaseReactiveIntegrationTests.java
@@ -1,6 +1,6 @@
 package org.springframework.data.aerospike;
 
-import com.aerospike.client.reactor.AerospikeReactorClient;
+import com.aerospike.client.reactor.IAerospikeReactorClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.aerospike.config.CommonTestConfig;
@@ -22,7 +22,7 @@ public abstract class BaseReactiveIntegrationTests extends BaseIntegrationTests 
     @Autowired
     protected ReactiveAerospikeTemplate reactiveTemplate;
     @Autowired
-    protected AerospikeReactorClient reactorClient;
+    protected IAerospikeReactorClient reactorClient;
 
     protected <T> T findById(Serializable id, Class<T> type) {
         return reactiveTemplate.findById(id, type).block();


### PR DESCRIPTION
Use IAerospikeReactorClient where possible instead of AerospikeReactorClient, to allow wiring a different client implementation if desired (eg AerospikeReactorRetryClient).